### PR TITLE
Fix inaccuracy in README (Kong interactions)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ Version 2.0. See the file "[LICENSE](LICENSE)" for more information.
 * Application health and availability monitoring
 * Optional integration with Kong gateway
   * Add/remove services on application discovery update
-  * Add/remove routes per tenant on application install/uninstall
 
 ## Compiling
 


### PR DESCRIPTION
## Purpose
The README was inaccurate about the interactions between mgr-applications and Kong.  It's the mgr-tenant-entitlements which creates/manages routes in Kong.  The mgr-applications only creates/manages services in Kong.
