### PR TITLE
MGRENTITLE-21 Fix kafka event assertions

### DIFF
--- a/src/test/java/org/folio/am/support/KafkaEventAssertions.java
+++ b/src/test/java/org/folio/am/support/KafkaEventAssertions.java
@@ -2,15 +2,14 @@ package org.folio.am.support;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.folio.am.integration.kafka.DiscoveryPublisher.DISCOVERY_DESTINATION;
+import static org.folio.common.utils.CollectionUtils.mapItems;
 import static org.folio.integration.kafka.KafkaUtils.getEnvTopicName;
 import static org.folio.test.FakeKafkaConsumer.getEvents;
-import static org.hamcrest.Matchers.hasSize;
 
 import java.util.Arrays;
 import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.apache.commons.lang3.ArrayUtils;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.awaitility.Awaitility;
 import org.awaitility.core.ConditionFactory;
@@ -26,12 +25,19 @@ public final class KafkaEventAssertions {
 
   public static void assertDiscoveryEvents(String... moduleIds) {
     var topic = getEnvTopicName(DISCOVERY_DESTINATION);
-    var kafkaEvents = await().until(() -> getEvents(topic, DiscoveryEvent.class), hasSize(moduleIds.length));
     var expectedEvents = Arrays.stream(moduleIds).map(DiscoveryEvent::new).collect(Collectors.toList());
-    assertThat(kafkaEvents).map(ConsumerRecord::value).containsExactlyInAnyOrderElementsOf(expectedEvents);
+    await().untilAsserted(() -> {
+      var consumerRecords = getEvents(topic, DiscoveryEvent.class);
+      var entitlementEvents = mapItems(consumerRecords, ConsumerRecord::value);
+      assertThat(entitlementEvents).containsSequence(expectedEvents);
+    });
   }
 
   public static void assertNoDiscoveryEvents() {
-    assertDiscoveryEvents(ArrayUtils.EMPTY_STRING_ARRAY);
+    var topic = getEnvTopicName(DISCOVERY_DESTINATION);
+    await().untilAsserted(() -> {
+      var consumerRecords = getEvents(topic, DiscoveryEvent.class);
+      assertThat(consumerRecords).isEmpty();
+    });
   }
 }


### PR DESCRIPTION
## Purpose

Fixes kafka event assertions for discovery events

## Approach

- applicaiton-poc-tools no longer cleans events after getEvents() call, so assertion must be updated

## TODOS and Open Questions

<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

- [ ] Check logging

## Learning

<!-- OPTIONAL
  Help out not only your reviewer but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries, or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.
