### PR TITLE
MGRAPPS-35: Manage service routes based on discovery information

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ docker run \
 | MAX_HTTP_REQUEST_HEADER_SIZE             | 200KB                        |   true   | Maximum size of the HTTP request header.                                                                                                                                                                   |
 | REGISTER_MODULE_IN_KONG                  | true                         |  false   | Defines if module must be registered in Kong (it will create for itself service and list of routes from module descriptor)                                                                                 |
 | ROUTER_PATH_PREFIX                       |                              |  false   | Defines routes prefix to be added to the generated endpoints by OpenAPI generator (`/foo/entites` -> `{{prefix}}/foo/entities`). Required if load balancing group has format like `{{host}}/{{moduleId}}`  |
+| ROUTEMANAGEMENT_ENABLE                   | false                        |  false   | Enable Kong routes management for modules discovery information (e.g. creation of routes on module discovery creation/update, removal of routes on deletion of module discovery information)               |
 
 ### SSL Configuration environment variables
 

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <spring-cloud-bom.version>2023.0.4</spring-cloud-bom.version>
     <cql2pgjson.version>35.3.0</cql2pgjson.version>
     <folio-spring-cql.version>8.2.1</folio-spring-cql.version>
-    <applications-poc-tools.version>2.1.0-SNAPSHOT</applications-poc-tools.version>
+    <applications-poc-tools.version>2.2.0-SNAPSHOT</applications-poc-tools.version>
     <folio-java-checkstyle.version>1.0.1</folio-java-checkstyle.version>
     <semver4j.version>5.4.1</semver4j.version>
 

--- a/src/main/java/org/folio/am/integration/kong/KongDiscoveryListener.java
+++ b/src/main/java/org/folio/am/integration/kong/KongDiscoveryListener.java
@@ -45,6 +45,7 @@ public class KongDiscoveryListener implements ApplicationDiscoveryListener {
    */
   @Override
   public void onDiscoveryUpdate(ModuleDiscovery moduleDiscovery, String token) {
+    deleteServiceKongRoutes(moduleDiscovery.getId());
     upsertService(moduleDiscovery);
   }
 
@@ -57,14 +58,7 @@ public class KongDiscoveryListener implements ApplicationDiscoveryListener {
    */
   @Override
   public void onDiscoveryDelete(String serviceId, String instanceId, String token) {
-    if (routeManagementEnable) {
-      try {
-        kongGatewayService.deleteServiceRoutes(serviceId);
-      } catch (NoSuchElementException nse) {
-        // Service doesn't exist - therefore no need to delete routes
-        log.debug("Service doesn't exist: {}", serviceId);
-      }
-    }
+    deleteServiceKongRoutes(serviceId);
     kongGatewayService.deleteService(serviceId);
     log.debug("discovery info removed from Kong");
   }
@@ -77,6 +71,17 @@ public class KongDiscoveryListener implements ApplicationDiscoveryListener {
     if (routeManagementEnable) {
       var moduleEntity = moduleRepository.findById(moduleDiscovery.getArtifactId()).orElseThrow();
       kongGatewayService.addRoutes(null, singletonList(moduleEntity.getDescriptor()));
+    }
+  }
+
+  private void deleteServiceKongRoutes(String serviceId) {
+    if (routeManagementEnable) {
+      try {
+        kongGatewayService.deleteServiceRoutes(serviceId);
+      } catch (NoSuchElementException nse) {
+        // Service doesn't exist - therefore no need to delete routes
+        log.debug("Service doesn't exist: {}", serviceId);
+      }
     }
   }
 }

--- a/src/main/java/org/folio/am/integration/kong/KongDiscoveryListener.java
+++ b/src/main/java/org/folio/am/integration/kong/KongDiscoveryListener.java
@@ -2,6 +2,7 @@ package org.folio.am.integration.kong;
 
 import static java.util.Collections.singletonList;
 
+import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.folio.am.domain.dto.ModuleDiscovery;
@@ -52,7 +53,12 @@ public class KongDiscoveryListener implements ApplicationDiscoveryListener {
    */
   @Override
   public void onDiscoveryDelete(String serviceId, String instanceId, String token) {
-    kongGatewayService.deleteServiceRoutes(serviceId);
+    try {
+      kongGatewayService.deleteServiceRoutes(serviceId);
+    } catch (NoSuchElementException nse) {
+      // Service doesn't exist - therefore no need to delete routes
+      log.debug("Service doesn't exist: {}", serviceId);
+    }
     kongGatewayService.deleteService(serviceId);
     log.debug("discovery info removed from Kong");
   }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -163,3 +163,6 @@ messaging:
           keep-alive: 600s
       scheduling:
         enabled: true
+
+routemanagement:
+  enable: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -165,4 +165,4 @@ messaging:
         enabled: true
 
 routemanagement:
-  enable: false
+  enable: ${ROUTEMANAGEMENT_ENABLE:false}

--- a/src/test/java/org/folio/am/integration/kong/KongDiscoveryListenerTest.java
+++ b/src/test/java/org/folio/am/integration/kong/KongDiscoveryListenerTest.java
@@ -6,9 +6,17 @@ import static org.folio.am.support.TestConstants.SERVICE_NAME;
 import static org.folio.am.support.TestConstants.SERVICE_VERSION;
 import static org.folio.am.support.TestConstants.UPDATED_URL;
 import static org.folio.am.support.TestValues.moduleDiscovery;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import java.util.Collections;
+import java.util.Optional;
+import org.folio.am.domain.entity.ModuleEntity;
+import org.folio.am.repository.ModuleRepository;
+import org.folio.common.domain.model.ModuleDescriptor;
 import org.folio.test.types.UnitTest;
 import org.folio.tools.kong.model.Service;
 import org.folio.tools.kong.service.KongGatewayService;
@@ -24,25 +32,37 @@ class KongDiscoveryListenerTest {
 
   @InjectMocks private KongDiscoveryListener service;
   @Mock private KongGatewayService kongAdminClient;
+  @Mock private ModuleRepository moduleRepository;
 
   @Test
   void onCreateDiscovery_positive() {
+    var mockModule = mock(ModuleEntity.class);
+    when(moduleRepository.findById(any())).thenReturn(Optional.of(mockModule));
+    var mockModuleDescriptor = mock(ModuleDescriptor.class);
+    when(mockModule.getDescriptor()).thenReturn(mockModuleDescriptor);
     var kongService = kongService(MODULE_URL);
     service.onDiscoveryCreate(moduleDiscovery(), null);
     verify(kongAdminClient).upsertService(kongService);
+    verify(kongAdminClient).addRoutes(null, Collections.singletonList(mockModuleDescriptor));
   }
 
   @Test
   void onUpdateDiscovery_positive() {
+    var mockModule = mock(ModuleEntity.class);
+    when(moduleRepository.findById(any())).thenReturn(Optional.of(mockModule));
+    var mockModuleDescriptor = mock(ModuleDescriptor.class);
+    when(mockModule.getDescriptor()).thenReturn(mockModuleDescriptor);
     var updatedService = kongService(UPDATED_URL);
     service.onDiscoveryUpdate(moduleDiscovery(SERVICE_NAME, SERVICE_VERSION, UPDATED_URL), null);
     verify(kongAdminClient).upsertService(updatedService);
+    verify(kongAdminClient).addRoutes(null, Collections.singletonList(mockModuleDescriptor));
   }
 
   @Test
   void onDeleteDiscovery_positive() {
     doNothing().when(kongAdminClient).deleteService(MODULE_ID);
     service.onDiscoveryDelete(MODULE_ID, null, null);
+    verify(kongAdminClient).deleteServiceRoutes(MODULE_ID);
     verify(kongAdminClient).deleteService(MODULE_ID);
   }
 

--- a/src/test/java/org/folio/am/integration/kong/KongDiscoveryListenerTest.java
+++ b/src/test/java/org/folio/am/integration/kong/KongDiscoveryListenerTest.java
@@ -55,6 +55,7 @@ class KongDiscoveryListenerTest {
     var updatedService = kongService(UPDATED_URL);
     service.onDiscoveryUpdate(moduleDiscovery(SERVICE_NAME, SERVICE_VERSION, UPDATED_URL), null);
     verify(kongAdminClient).upsertService(updatedService);
+    verify(kongAdminClient).deleteServiceRoutes(MODULE_ID);
     verify(kongAdminClient).addRoutes(null, Collections.singletonList(mockModuleDescriptor));
   }
 

--- a/src/test/java/org/folio/am/it/ApplicationDiscoveryIT.java
+++ b/src/test/java/org/folio/am/it/ApplicationDiscoveryIT.java
@@ -67,7 +67,7 @@ class ApplicationDiscoveryIT extends BaseIntegrationTest {
 
   @AfterEach
   void tearDown() {
-    kongAdminClient.deleteService(MODULE_FOO_ID);
+    deleteService(MODULE_FOO_ID);
   }
 
   @Test
@@ -355,5 +355,15 @@ class ApplicationDiscoveryIT extends BaseIntegrationTest {
       assertThat(service.getPort()).isEqualTo(url.getPort());
       assertThat(service.getPath()).isEqualTo(stripToNull(url.getPath()));
     });
+  }
+
+  private void deleteService(String serviceId) {
+    try {
+      kongAdminClient.getServiceRoutes(serviceId, null)
+        .forEach(route -> kongAdminClient.deleteRoute(serviceId, route.getId()));
+    } catch (NotFound nf) {
+      // Do nothing
+    }
+    kongAdminClient.deleteService(serviceId);
   }
 }

--- a/src/test/java/org/folio/am/it/ApplicationDiscoveryKongIT.java
+++ b/src/test/java/org/folio/am/it/ApplicationDiscoveryKongIT.java
@@ -42,6 +42,7 @@ import org.folio.am.support.base.BaseIntegrationTest;
 import org.folio.common.utils.OkapiHeaders;
 import org.folio.test.types.IntegrationTest;
 import org.folio.tools.kong.client.KongAdminClient;
+import org.folio.tools.kong.model.Route;
 import org.folio.tools.kong.model.Service;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -222,6 +223,10 @@ class ApplicationDiscoveryKongIT extends BaseIntegrationTest {
   void delete_positive() throws Exception {
     kongAdminClient.upsertService(MODULE_BAR_ID, new Service().name(MODULE_BAR_ID).url(MODULE_BAR_URL));
     kongAdminClient.upsertService(MODULE_FOO_ID, new Service().name(MODULE_FOO_ID).url(MODULE_FOO_URL));
+    kongAdminClient.upsertRoute(MODULE_FOO_ID, MODULE_FOO_ID + "_testroute1",
+      new Route().name("testroute1foo").expression("http.path == \"/foo/foo\" && http.method == \"POST\""));
+    kongAdminClient.upsertRoute(MODULE_BAR_ID, MODULE_BAR_ID + "_testroute1",
+      new Route().name("testroute1bar").expression("http.path == \"/foo/foo\" && http.method == \"POST\""));
 
     mockMvc.perform(delete("/modules/{id}/discovery", MODULE_FOO_ID)
         .header(OkapiHeaders.TOKEN, OKAPI_AUTH_TOKEN))

--- a/src/test/java/org/folio/am/it/ApplicationDiscoveryKongIT.java
+++ b/src/test/java/org/folio/am/it/ApplicationDiscoveryKongIT.java
@@ -110,7 +110,8 @@ class ApplicationDiscoveryKongIT extends BaseIntegrationTest {
 
     var routes = kongAdminClient.getServiceRoutes(MODULE_BAR_ID, null);
     assertThat(routes.getData()).hasSize(1);
-    assertThat(routes.getData().get(0).getExpression()).contains("(http.path == \"/foo/bar\" && http.method == \"POST\")");
+    assertThat(routes.getData().get(0).getExpression()).contains(
+      "(http.path == \"/foo/bar\" && http.method == \"POST\")");
 
     assertDiscoveryEvents(MODULE_BAR_ID);
   }

--- a/src/test/resources/application-it.yml
+++ b/src/test/resources/application-it.yml
@@ -39,3 +39,5 @@ application:
         folio_master_folio-backend-admin-client: ${KC_ADMIN_CLIENT_SECRET}
   validation:
     default-mode: basic
+routemanagement:
+  enable: true

--- a/src/test/resources/sql/module-discoveries-it.sql
+++ b/src/test/resources/sql/module-discoveries-it.sql
@@ -13,9 +13,9 @@ VALUES
 
 INSERT INTO module(id, name, version, descriptor, discovery_url)
 VALUES
-    ('test-module-foo-1.0.0', 'test-module-foo', '1.0.0', '{}', NULL),
-    ('test-module-bar-1.0.0', 'test-module-bar', '1.0.0', '{}', NULL),
-    ('test-module-baz-1.0.0', 'test-module-baz', '1.0.0', '{}', NULL);
+    ('test-module-foo-1.0.0', 'test-module-foo', '1.0.0', '{"id":"test-module-foo-1.0.0", "provides": [ { "id": "foo", "version": "1.0", "handlers": [ { "methods": [ "POST" ], "pathPattern": "/foo/foo", "permissionsRequired": [ "foo.post" ], "modulePermissions": [ "foo.item.get" ] } ] } ]}', NULL),
+    ('test-module-bar-1.0.0', 'test-module-bar', '1.0.0', '{"id":"test-module-bar-1.0.0", "provides": [ { "id": "bar", "version": "1.0", "handlers": [ { "methods": [ "POST" ], "pathPattern": "/foo/bar", "permissionsRequired": [ "bar.post" ], "modulePermissions": [ "bar.item.get" ] } ] } ]}', NULL),
+    ('test-module-baz-1.0.0', 'test-module-baz', '1.0.0', '{"id":"test-module-baz-1.0.0", "provides": [ { "id": "baz", "version": "1.0", "handlers": [ { "methods": [ "POST" ], "pathPattern": "/foo/baz", "permissionsRequired": [ "baz.post" ], "modulePermissions": [ "baz.item.get" ] } ] } ]}', NULL);
 
 INSERT INTO application_module(application_id, module_id)
 VALUES


### PR DESCRIPTION
## Purpose

In order to optimise Kong routing performance we should create routes tenant-independent based on module discovery information, and delete rotes when module discovery is deleted.

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.
