### PR TITLE
MGRAPPS-70: Consume entitlement Kafka events for Kong route mgmt.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 * mgr-applications FAR mode semver dependency validation fails with SNAPSHOT version ranges(MGRAPPS-68)
 * Fix test for tenant header Kong route expression updated in application-poc-tools (APPPOCTOOL-64)
 * FAR mode OOM crash due to excessive memory consumption during validation (MGRAPPS-67)
+* Consume entitlement Kafka events for Kong route mgmt (MGRAPPS-70)
 ---
 
 ## Version `v3.0.0` (12.03.2025)

--- a/src/main/java/org/folio/am/integration/kafka/EntitlementEventListener.java
+++ b/src/main/java/org/folio/am/integration/kafka/EntitlementEventListener.java
@@ -1,0 +1,41 @@
+package org.folio.am.integration.kafka;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.folio.am.integration.kafka.model.TenantEntitlementEvent;
+import org.folio.tools.kong.service.KongGatewayService;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Log4j2
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(value = "application.kong.tenant-checks.enabled", havingValue = "true")
+public class EntitlementEventListener {
+
+  private final KongGatewayService gatewayService;
+
+  @KafkaListener(
+    topics = "${kafka.topics.entitlement}",
+    containerFactory = "entitlementKafkaListenerContainerFactory")
+  public void onEntitlementEvent(TenantEntitlementEvent event) {
+    log.info("Received entitlement event: {}", event);
+
+    var moduleId = event.getModuleId();
+    var tenant = event.getTenantName();
+    var type = event.getType();
+
+    if (type == null) {
+      log.warn("Unsupported event type: null");
+      return;
+    }
+
+    switch (type) {
+      case ENTITLE, UPGRADE -> gatewayService.addTenantToModuleRoutes(moduleId, tenant);
+      case REVOKE -> gatewayService.removeTenantFromModuleRoutes(moduleId, tenant);
+      default -> log.warn("Unsupported event type: {}", type);
+    }
+  }
+}
+

--- a/src/main/java/org/folio/am/integration/kafka/config/EntitlementConsumerConfiguration.java
+++ b/src/main/java/org/folio/am/integration/kafka/config/EntitlementConsumerConfiguration.java
@@ -1,0 +1,75 @@
+package org.folio.am.integration.kafka.config;
+
+import java.util.HashMap;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.folio.am.integration.kafka.model.TenantEntitlementEvent;
+import org.folio.tools.kong.exception.TenantRouteUpdateException;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.KafkaException;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.util.backoff.BackOff;
+import org.springframework.util.backoff.FixedBackOff;
+
+@Log4j2
+@Configuration
+@RequiredArgsConstructor
+@ConditionalOnProperty(value = "application.kong.tenant-checks.enabled", havingValue = "true")
+public class EntitlementConsumerConfiguration {
+
+  private final KafkaProperties kafkaProperties;
+  private final TenantRoutesRetryConfiguration retryConfiguration;
+
+  @Bean
+  public ConcurrentKafkaListenerContainerFactory<String, TenantEntitlementEvent>
+    entitlementKafkaListenerContainerFactory() {
+    var props = new HashMap<>(kafkaProperties.buildConsumerProperties(null));
+    props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+    props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+    props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+
+    var jd = new JsonDeserializer<>(TenantEntitlementEvent.class);
+    jd.addTrustedPackages("org.folio.am.integration.kafka.model");
+
+    var cf = new DefaultKafkaConsumerFactory<>(props, new StringDeserializer(), jd);
+    var factory = new ConcurrentKafkaListenerContainerFactory<String, TenantEntitlementEvent>();
+
+    factory.setConsumerFactory(cf);
+    factory.setCommonErrorHandler(eventErrorHandler());
+    return factory;
+  }
+
+  private DefaultErrorHandler eventErrorHandler() {
+    var errorHandler = new DefaultErrorHandler((message, exception) ->
+      log.warn("Failed to process event [record: {}]", message, exception.getCause()));
+    errorHandler.setBackOffFunction((message, exception) -> getBackOff(exception));
+    errorHandler.setLogLevel(KafkaException.Level.DEBUG);
+
+    return errorHandler;
+  }
+
+  private BackOff getBackOff(Exception exception) {
+    var throwable = findTenantUpdateException(exception);
+    if (throwable.isPresent()) {
+      log.warn("Error during tenant routes change [message: {}]", throwable.get().getMessage());
+      return new FixedBackOff(retryConfiguration.getRetryDelay().toMillis(), retryConfiguration.getRetryAttempts());
+    }
+
+    return new FixedBackOff(0L, 0L);
+  }
+
+  private static Optional<Throwable> findTenantUpdateException(Exception exception) {
+    return Optional.of(exception)
+      .map(Throwable::getCause)
+      .filter(TenantRouteUpdateException.class::isInstance);
+  }
+}

--- a/src/main/java/org/folio/am/integration/kafka/config/TenantRoutesRetryConfiguration.java
+++ b/src/main/java/org/folio/am/integration/kafka/config/TenantRoutesRetryConfiguration.java
@@ -1,0 +1,23 @@
+package org.folio.am.integration.kafka.config;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import java.time.Duration;
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+@Data
+@Component
+@Validated
+@ConfigurationProperties("application.retry.tenant-routes")
+public class TenantRoutesRetryConfiguration {
+
+  @NotNull
+  private Duration retryDelay;
+
+  @NotNull
+  @Positive
+  private long retryAttempts;
+}

--- a/src/main/java/org/folio/am/integration/kafka/model/TenantEntitlementEvent.java
+++ b/src/main/java/org/folio/am/integration/kafka/model/TenantEntitlementEvent.java
@@ -1,0 +1,30 @@
+package org.folio.am.integration.kafka.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor(staticName = "of")
+public class TenantEntitlementEvent {
+  @JsonProperty("moduleId")
+  private String moduleId;
+
+  @JsonProperty("tenantName")
+  private String tenantName;
+
+  @JsonProperty("tenantId")
+  private UUID tenantId;
+
+  @JsonProperty("type")
+  private Type type;
+
+  public enum Type {
+    ENTITLE,
+    UPGRADE,
+    REVOKE
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,6 +35,8 @@ spring:
         max.in.flight.requests.per.connection: 5
         retries: 5
         spring.json.add.type.headers: false
+    topics:
+      entitlement: ${KAFKA_ENTITLEMENT_TOPIC:${application.environment}.entitlement}
   cloud:
     openfeign:
       okhttp:
@@ -59,6 +61,8 @@ application:
     read-timeout: ${KONG_READ_TIMEOUT:}
     write-timeout: ${KONG_WRITE_TIMEOUT:}
     retries: ${KONG_RETRIES:}
+    tenant-checks:
+      enabled: ${KONG_TENANT_CHECKS_ENABLED:false}
     tls:
       enabled: ${KONG_TLS_ENABLED:false}
       trust-store-path: ${KONG_TLS_TRUSTSTORE_PATH:}
@@ -74,6 +78,10 @@ application:
       - name: discovery
         numPartitions: ${KAFKA_DISCOVERY_TOPIC_PARTITIONS:1}
         replicationFactor: ${KAFKA_DISCOVERY_TOPIC_REPLICATION_FACTOR:}
+  retry:
+    tenant-routes:
+      retry-delay: ${TENANT_ROUTES_RETRY_DELAY:500ms}
+      retry-attempts: ${TENANT_ROUTES_RETRY_ATTEMPTS:10}
   keycloak:
     enabled: ${KC_INTEGRATION_ENABLED:true}
     url: ${KC_URL:http://keycloak:8080}

--- a/src/test/java/org/folio/am/integration/kafka/EntitlementEventListenerTest.java
+++ b/src/test/java/org/folio/am/integration/kafka/EntitlementEventListenerTest.java
@@ -1,0 +1,71 @@
+package org.folio.am.integration.kafka;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.util.UUID;
+import org.folio.am.integration.kafka.model.TenantEntitlementEvent;
+import org.folio.test.types.UnitTest;
+import org.folio.tools.kong.service.KongGatewayService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@UnitTest
+@ExtendWith(MockitoExtension.class)
+class EntitlementEventListenerTest {
+
+  private static final String MODULE_ID = "test-module-1.0.0";
+  private static final String TENANT_NAME = "test-tenant";
+  private static final UUID TENANT_ID = UUID.randomUUID();
+
+  @Mock private KongGatewayService kongGatewayService;
+
+  @InjectMocks private EntitlementEventListener listener;
+
+  @Test
+  void onEntitlementEvent_positive_entitleEvent() {
+    var event = entitlementEvent(TenantEntitlementEvent.Type.ENTITLE);
+
+    listener.onEntitlementEvent(event);
+
+    verify(kongGatewayService).addTenantToModuleRoutes(MODULE_ID, TENANT_NAME);
+    verifyNoMoreInteractions(kongGatewayService);
+  }
+
+  @Test
+  void onEntitlementEvent_positive_upgradeEvent() {
+    var event = entitlementEvent(TenantEntitlementEvent.Type.UPGRADE);
+
+    listener.onEntitlementEvent(event);
+
+    verify(kongGatewayService).addTenantToModuleRoutes(MODULE_ID, TENANT_NAME);
+    verifyNoMoreInteractions(kongGatewayService);
+  }
+
+  @Test
+  void onEntitlementEvent_positive_revokeEvent() {
+    var event = entitlementEvent(TenantEntitlementEvent.Type.REVOKE);
+
+    listener.onEntitlementEvent(event);
+
+    verify(kongGatewayService).removeTenantFromModuleRoutes(MODULE_ID, TENANT_NAME);
+    verifyNoMoreInteractions(kongGatewayService);
+  }
+
+  @Test
+  void onEntitlementEvent_positive_nullEventType() {
+    var event = TenantEntitlementEvent.of(MODULE_ID, TENANT_NAME, TENANT_ID, null);
+
+    listener.onEntitlementEvent(event);
+
+    verifyNoInteractions(kongGatewayService);
+  }
+
+  private static TenantEntitlementEvent entitlementEvent(TenantEntitlementEvent.Type type) {
+    return TenantEntitlementEvent.of(MODULE_ID, TENANT_NAME, TENANT_ID, type);
+  }
+}

--- a/src/test/java/org/folio/am/integration/kafka/config/EntitlementConsumerConfigurationTest.java
+++ b/src/test/java/org/folio/am/integration/kafka/config/EntitlementConsumerConfigurationTest.java
@@ -1,0 +1,126 @@
+package org.folio.am.integration.kafka.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.folio.test.types.UnitTest;
+import org.folio.tools.kong.exception.TenantRouteUpdateException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.util.backoff.BackOff;
+import org.springframework.util.backoff.FixedBackOff;
+
+@UnitTest
+@ExtendWith(MockitoExtension.class)
+class EntitlementConsumerConfigurationTest {
+
+  @Mock private KafkaProperties kafkaProperties;
+  @Mock private TenantRoutesRetryConfiguration retryConfiguration;
+
+  @InjectMocks private EntitlementConsumerConfiguration configuration;
+
+  @BeforeEach
+  void setUp() {
+    lenient().when(kafkaProperties.buildConsumerProperties(null))
+      .thenReturn(defaultKafkaConsumerProperties());
+    lenient().when(retryConfiguration.getRetryDelay()).thenReturn(Duration.ofMillis(250));
+    lenient().when(retryConfiguration.getRetryAttempts()).thenReturn(5L);
+  }
+
+  @Test
+  void entitlementKafkaListenerContainerFactory_positive() {
+    var factory = configuration.entitlementKafkaListenerContainerFactory();
+
+    assertThat(factory).isNotNull();
+    assertThat(factory.getConsumerFactory()).isNotNull();
+
+    var consumerFactory = factory.getConsumerFactory();
+    var configMap = consumerFactory.getConfigurationProperties();
+
+    assertThat(configMap)
+      .containsEntry(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class)
+      .containsEntry(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class)
+      .containsEntry(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+  }
+
+  @Test
+  void entitlementKafkaListenerContainerFactory_positive_consumerProperties() {
+    var factory = configuration.entitlementKafkaListenerContainerFactory();
+
+    var consumerFactory = factory.getConsumerFactory();
+    var configMap = consumerFactory.getConfigurationProperties();
+
+    assertThat(configMap)
+      .containsKey(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG)
+      .containsKey(ConsumerConfig.GROUP_ID_CONFIG);
+  }
+
+  @Test
+  void backoffLogic_positive_tenantRouteUpdateException() {
+    // Create exception with TenantRouteUpdateException as cause
+    var tenantUpdateException = new TenantRouteUpdateException("Route update failed");
+    var kafkaException = new Exception(tenantUpdateException);
+
+    var backOff = getBackOffForException(kafkaException);
+
+    assertThat(backOff).isInstanceOf(FixedBackOff.class);
+    var fixedBackOff = (FixedBackOff) backOff;
+    assertThat(fixedBackOff.getInterval()).isEqualTo(250L);
+    assertThat(fixedBackOff.getMaxAttempts()).isEqualTo(5L);
+  }
+
+  @Test
+  void backoffLogic_positive_otherException() {
+    // Create exception without TenantRouteUpdateException
+    var genericException = new Exception(new RuntimeException("Generic error"));
+
+    var backOff = getBackOffForException(genericException);
+
+    assertThat(backOff).isInstanceOf(FixedBackOff.class);
+    var fixedBackOff = (FixedBackOff) backOff;
+    assertThat(fixedBackOff.getInterval()).isZero();
+    assertThat(fixedBackOff.getMaxAttempts()).isZero();
+  }
+
+  @Test
+  void backoffLogic_positive_nestedTenantRouteUpdateException() {
+    // Create nested exception with TenantRouteUpdateException
+    var tenantUpdateException = new TenantRouteUpdateException("Kong route update failed");
+    var wrappedException = new RuntimeException(tenantUpdateException);
+
+    var backOff = getBackOffForException(wrappedException);
+
+    assertThat(backOff).isInstanceOf(FixedBackOff.class);
+    var fixedBackOff = (FixedBackOff) backOff;
+    assertThat(fixedBackOff.getInterval()).isEqualTo(250L);
+    assertThat(fixedBackOff.getMaxAttempts()).isEqualTo(5L);
+  }
+
+  private BackOff getBackOffForException(Exception exception) {
+    try {
+      var method = EntitlementConsumerConfiguration.class.getDeclaredMethod("getBackOff", Exception.class);
+      method.setAccessible(true);
+      return (org.springframework.util.backoff.BackOff) method.invoke(configuration, exception);
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to invoke getBackOff method", e);
+    }
+  }
+
+  private Map<String, Object> defaultKafkaConsumerProperties() {
+    var props = new HashMap<String, Object>();
+    props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+    props.put(ConsumerConfig.GROUP_ID_CONFIG, "test-group");
+    return props;
+  }
+}

--- a/src/test/java/org/folio/am/integration/kafka/config/EntitlementConsumerConfigurationTest.java
+++ b/src/test/java/org/folio/am/integration/kafka/config/EntitlementConsumerConfigurationTest.java
@@ -111,7 +111,7 @@ class EntitlementConsumerConfigurationTest {
     try {
       var method = EntitlementConsumerConfiguration.class.getDeclaredMethod("getBackOff", Exception.class);
       method.setAccessible(true);
-      return (org.springframework.util.backoff.BackOff) method.invoke(configuration, exception);
+      return (BackOff) method.invoke(configuration, exception);
     } catch (Exception e) {
       throw new RuntimeException("Failed to invoke getBackOff method", e);
     }

--- a/src/test/java/org/folio/am/integration/kafka/config/TenantRoutesRetryConfigurationTest.java
+++ b/src/test/java/org/folio/am/integration/kafka/config/TenantRoutesRetryConfigurationTest.java
@@ -1,0 +1,31 @@
+package org.folio.am.integration.kafka.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import org.folio.test.types.UnitTest;
+import org.junit.jupiter.api.Test;
+
+@UnitTest
+class TenantRoutesRetryConfigurationTest {
+
+  @Test
+  void setRetryDelay_positive() {
+    var config = new TenantRoutesRetryConfiguration();
+    var customDelay = Duration.ofSeconds(5);
+
+    config.setRetryDelay(customDelay);
+
+    assertThat(config.getRetryDelay()).isEqualTo(customDelay);
+  }
+
+  @Test
+  void setRetryAttempts_positive() {
+    var config = new TenantRoutesRetryConfiguration();
+    var customAttempts = 10L;
+
+    config.setRetryAttempts(customAttempts);
+
+    assertThat(config.getRetryAttempts()).isEqualTo(customAttempts);
+  }
+}

--- a/src/test/java/org/folio/am/it/EntitlementEventListenerIT.java
+++ b/src/test/java/org/folio/am/it/EntitlementEventListenerIT.java
@@ -1,0 +1,369 @@
+package org.folio.am.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.awaitility.Durations.FIVE_SECONDS;
+import static org.awaitility.Durations.TEN_SECONDS;
+import static org.folio.am.support.TestConstants.MODULE_BAR_ID;
+import static org.folio.am.support.TestConstants.MODULE_BAR_NAME;
+import static org.folio.am.support.TestConstants.MODULE_BAR_URL;
+import static org.folio.am.support.TestConstants.MODULE_BAR_VERSION;
+import static org.folio.am.support.TestConstants.MODULE_FOO_ID;
+import static org.folio.am.support.TestConstants.MODULE_FOO_NAME;
+import static org.folio.am.support.TestConstants.MODULE_FOO_URL;
+import static org.folio.am.support.TestConstants.MODULE_FOO_VERSION;
+import static org.folio.am.support.TestConstants.OKAPI_AUTH_TOKEN;
+import static org.folio.am.support.TestValues.moduleDiscovery;
+import static org.folio.test.TestUtils.asJsonString;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
+import static org.springframework.test.context.jdbc.SqlMergeMode.MergeMode.MERGE;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.UUID;
+import org.folio.am.integration.kafka.model.TenantEntitlementEvent;
+import org.folio.am.support.base.BaseIntegrationTest;
+import org.folio.am.support.config.KafkaTestConfiguration;
+import org.folio.common.utils.OkapiHeaders;
+import org.folio.test.types.IntegrationTest;
+import org.folio.tools.kong.client.KongAdminClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Import;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.SqlMergeMode;
+
+@IntegrationTest
+@SqlMergeMode(MERGE)
+@Sql(scripts = "classpath:/sql/truncate-tables.sql", executionPhase = AFTER_TEST_METHOD)
+@Import(KafkaTestConfiguration.class)
+@TestPropertySource(properties = {
+  "application.okapi.enabled=false",
+  "application.kong.enabled=true",
+  "application.kong.tenant-checks.enabled=true"
+})
+class EntitlementEventListenerIT extends BaseIntegrationTest {
+
+  private static final String TENANT_1 = "tenant1";
+  private static final String TENANT_2 = "tenant2";
+  private static final String TENANT_3 = "tenant3";
+
+  @Value("${kafka.topics.entitlement}")
+  private String entitlementTopic;
+
+  @Autowired private KongAdminClient kongAdminClient;
+  @Autowired private KafkaTemplate<String, Object> kafkaTemplate;
+
+  @BeforeAll
+  static void setUp(@Autowired ApplicationContext applicationContext) {
+    assertThat(applicationContext.containsBean("folioKongAdminClient")).isTrue();
+    assertThat(applicationContext.containsBean("folioKongGatewayService")).isTrue();
+    assertThat(applicationContext.containsBean("kongDiscoveryListener")).isTrue();
+    assertThat(applicationContext.containsBean("entitlementEventListener")).isTrue();
+    assertThat(applicationContext.containsBean("entitlementKafkaListenerContainerFactory")).isTrue();
+    assertThat(applicationContext.containsBean("okapiClient")).isFalse();
+  }
+
+  @AfterEach
+  void tearDown() {
+    deleteServiceSafely(MODULE_FOO_ID);
+    deleteServiceSafely(MODULE_BAR_ID);
+  }
+
+  @Test
+  @Sql(scripts = "classpath:/sql/module-discoveries-it.sql")
+  void entitlementEvent_positive_addFirstTenant() throws Exception {
+    // Create module discovery to register Kong service and routes
+    createModuleDiscovery(MODULE_FOO_ID, MODULE_FOO_NAME, MODULE_FOO_VERSION, MODULE_FOO_URL);
+
+    // Verify initial route has wildcard expression
+    var routesBefore = kongAdminClient.getServiceRoutes(MODULE_FOO_ID, null);
+    assertThat(routesBefore.getData()).hasSize(1);
+    var initialExpression = routesBefore.getData().getFirst().getExpression();
+    assertThat(initialExpression).contains("x_okapi_tenant ~ r#\".*\"#");
+
+    // Send ENTITLE event for first tenant
+    sendEntitlementEvent(MODULE_FOO_ID, TENANT_1, TenantEntitlementEvent.Type.ENTITLE);
+
+    // Verify route expression updated to include specific tenant
+    await().atMost(TEN_SECONDS).untilAsserted(() -> {
+      var routes = kongAdminClient.getServiceRoutes(MODULE_FOO_ID, null);
+      assertThat(routes.getData()).hasSize(1);
+      var expression = routes.getData().getFirst().getExpression();
+      assertThat(expression).contains("x_okapi_tenant");
+      assertThat(expression).contains(TENANT_1);
+      assertThat(expression).doesNotContain("~ r#\".*\"#"); // Wildcard removed
+    });
+  }
+
+  @Test
+  @Sql(scripts = "classpath:/sql/module-discoveries-it.sql")
+  void entitlementEvent_positive_addMultipleTenants() throws Exception {
+    // Create module discovery
+    createModuleDiscovery(MODULE_FOO_ID, MODULE_FOO_NAME, MODULE_FOO_VERSION, MODULE_FOO_URL);
+
+    // Send ENTITLE events for multiple tenants
+    sendEntitlementEvent(MODULE_FOO_ID, TENANT_1, TenantEntitlementEvent.Type.ENTITLE);
+    sendEntitlementEvent(MODULE_FOO_ID, TENANT_2, TenantEntitlementEvent.Type.ENTITLE);
+    sendEntitlementEvent(MODULE_FOO_ID, TENANT_3, TenantEntitlementEvent.Type.ENTITLE);
+
+    // Verify all tenants are in route expression
+    await().atMost(TEN_SECONDS).untilAsserted(() -> {
+      var routes = kongAdminClient.getServiceRoutes(MODULE_FOO_ID, null);
+      assertThat(routes.getData()).hasSize(1);
+      var expression = routes.getData().getFirst().getExpression();
+      assertThat(expression).contains(TENANT_1);
+      assertThat(expression).contains(TENANT_2);
+      assertThat(expression).contains(TENANT_3);
+      assertThat(expression).contains("||"); // OR operator between tenants
+    });
+  }
+
+  @Test
+  @Sql(scripts = "classpath:/sql/module-discoveries-it.sql")
+  void entitlementEvent_positive_upgradeEvent() throws Exception {
+    // Create module discovery
+    createModuleDiscovery(MODULE_FOO_ID, MODULE_FOO_NAME, MODULE_FOO_VERSION, MODULE_FOO_URL);
+
+    // Send UPGRADE event (should behave same as ENTITLE)
+    sendEntitlementEvent(MODULE_FOO_ID, TENANT_1, TenantEntitlementEvent.Type.UPGRADE);
+
+    // Verify tenant added
+    await().atMost(TEN_SECONDS).untilAsserted(() -> {
+      var routes = kongAdminClient.getServiceRoutes(MODULE_FOO_ID, null);
+      assertThat(routes.getData()).hasSize(1);
+      var expression = routes.getData().getFirst().getExpression();
+      assertThat(expression).contains(TENANT_1);
+    });
+  }
+
+  @Test
+  @Sql(scripts = "classpath:/sql/module-discoveries-it.sql")
+  void entitlementEvent_positive_revokeTenant() throws Exception {
+    // Create module discovery
+    createModuleDiscovery(MODULE_FOO_ID, MODULE_FOO_NAME, MODULE_FOO_VERSION, MODULE_FOO_URL);
+
+    // Add multiple tenants
+    sendEntitlementEvent(MODULE_FOO_ID, TENANT_1, TenantEntitlementEvent.Type.ENTITLE);
+    sendEntitlementEvent(MODULE_FOO_ID, TENANT_2, TenantEntitlementEvent.Type.ENTITLE);
+
+    await().atMost(TEN_SECONDS).untilAsserted(() -> {
+      var routes = kongAdminClient.getServiceRoutes(MODULE_FOO_ID, null);
+      var expression = routes.getData().getFirst().getExpression();
+      assertThat(expression).contains(TENANT_1);
+      assertThat(expression).contains(TENANT_2);
+    });
+
+    // Revoke one tenant
+    sendEntitlementEvent(MODULE_FOO_ID, TENANT_1, TenantEntitlementEvent.Type.REVOKE);
+
+    // Verify only TENANT_2 remains
+    await().atMost(TEN_SECONDS).untilAsserted(() -> {
+      var routes = kongAdminClient.getServiceRoutes(MODULE_FOO_ID, null);
+      assertThat(routes.getData()).hasSize(1);
+      var expression = routes.getData().getFirst().getExpression();
+      assertThat(expression).doesNotContain(TENANT_1);
+      assertThat(expression).contains(TENANT_2);
+    });
+  }
+
+  @Test
+  @Sql(scripts = "classpath:/sql/module-discoveries-it.sql")
+  void entitlementEvent_positive_revokeLastTenant() throws Exception {
+    // Create module discovery
+    createModuleDiscovery(MODULE_FOO_ID, MODULE_FOO_NAME, MODULE_FOO_VERSION, MODULE_FOO_URL);
+
+    // Add one tenant
+    sendEntitlementEvent(MODULE_FOO_ID, TENANT_1, TenantEntitlementEvent.Type.ENTITLE);
+
+    await().atMost(TEN_SECONDS).untilAsserted(() -> {
+      var routes = kongAdminClient.getServiceRoutes(MODULE_FOO_ID, null);
+      var expression = routes.getData().getFirst().getExpression();
+      assertThat(expression).contains(TENANT_1);
+    });
+
+    // Revoke last tenant - should restore wildcard
+    sendEntitlementEvent(MODULE_FOO_ID, TENANT_1, TenantEntitlementEvent.Type.REVOKE);
+
+    // Verify wildcard restored
+    await().atMost(TEN_SECONDS).untilAsserted(() -> {
+      var routes = kongAdminClient.getServiceRoutes(MODULE_FOO_ID, null);
+      assertThat(routes.getData()).hasSize(1);
+      var expression = routes.getData().getFirst().getExpression();
+      assertThat(expression).contains("x_okapi_tenant ~ r#\".*\"#"); // Wildcard restored
+      assertThat(expression).doesNotContain(TENANT_1);
+    });
+  }
+
+  @Test
+  @Sql(scripts = "classpath:/sql/module-discoveries-it.sql")
+  void entitlementEvent_positive_multipleModules() throws Exception {
+    // Create discoveries for multiple modules
+    createModuleDiscovery(MODULE_FOO_ID, MODULE_FOO_NAME, MODULE_FOO_VERSION, MODULE_FOO_URL);
+    createModuleDiscovery(MODULE_BAR_ID, MODULE_BAR_NAME, MODULE_BAR_VERSION, MODULE_BAR_URL);
+
+    // Add tenants to different modules
+    sendEntitlementEvent(MODULE_FOO_ID, TENANT_1, TenantEntitlementEvent.Type.ENTITLE);
+    sendEntitlementEvent(MODULE_BAR_ID, TENANT_2, TenantEntitlementEvent.Type.ENTITLE);
+
+    // Verify each module has its own tenant
+    await().atMost(TEN_SECONDS).untilAsserted(() -> {
+      var fooRoutes = kongAdminClient.getServiceRoutes(MODULE_FOO_ID, null);
+      var fooExpression = fooRoutes.getData().getFirst().getExpression();
+      assertThat(fooExpression).contains(TENANT_1);
+      assertThat(fooExpression).doesNotContain(TENANT_2);
+
+      var barRoutes = kongAdminClient.getServiceRoutes(MODULE_BAR_ID, null);
+      var barExpression = barRoutes.getData().getFirst().getExpression();
+      assertThat(barExpression).contains(TENANT_2);
+      assertThat(barExpression).doesNotContain(TENANT_1);
+    });
+  }
+
+  @Test
+  @Sql(scripts = "classpath:/sql/module-discoveries-it.sql")
+  void entitlementEvent_positive_idempotentOperations() throws Exception {
+    // Create module discovery
+    createModuleDiscovery(MODULE_FOO_ID, MODULE_FOO_NAME, MODULE_FOO_VERSION, MODULE_FOO_URL);
+
+    // Send same ENTITLE event twice
+    sendEntitlementEvent(MODULE_FOO_ID, TENANT_1, TenantEntitlementEvent.Type.ENTITLE);
+    sendEntitlementEvent(MODULE_FOO_ID, TENANT_1, TenantEntitlementEvent.Type.ENTITLE);
+
+    // Verify tenant appears only once
+    await().atMost(TEN_SECONDS).untilAsserted(() -> {
+      var routes = kongAdminClient.getServiceRoutes(MODULE_FOO_ID, null);
+      assertThat(routes.getData()).hasSize(1);
+      var expression = routes.getData().getFirst().getExpression();
+      assertThat(expression).contains(TENANT_1);
+      // Count occurrences of tenant name - should appear only once
+      var count = expression.split(TENANT_1, -1).length - 1;
+      assertThat(count).isEqualTo(1);
+    });
+  }
+
+  @Test
+  @Sql(scripts = "classpath:/sql/module-discoveries-it.sql")
+  void entitlementEvent_positive_complexScenario() throws Exception {
+    // Create module discovery
+    createModuleDiscovery(MODULE_FOO_ID, MODULE_FOO_NAME, MODULE_FOO_VERSION, MODULE_FOO_URL);
+
+    // Add multiple tenants
+    sendEntitlementEvent(MODULE_FOO_ID, TENANT_1, TenantEntitlementEvent.Type.ENTITLE);
+    sendEntitlementEvent(MODULE_FOO_ID, TENANT_2, TenantEntitlementEvent.Type.ENTITLE);
+    sendEntitlementEvent(MODULE_FOO_ID, TENANT_3, TenantEntitlementEvent.Type.ENTITLE);
+
+    await().atMost(TEN_SECONDS).untilAsserted(() -> {
+      var routes = kongAdminClient.getServiceRoutes(MODULE_FOO_ID, null);
+      var expression = routes.getData().getFirst().getExpression();
+      assertThat(expression).contains(TENANT_1, TENANT_2, TENANT_3);
+    });
+
+    // Revoke middle tenant
+    sendEntitlementEvent(MODULE_FOO_ID, TENANT_2, TenantEntitlementEvent.Type.REVOKE);
+
+    await().atMost(TEN_SECONDS).untilAsserted(() -> {
+      var routes = kongAdminClient.getServiceRoutes(MODULE_FOO_ID, null);
+      var expression = routes.getData().getFirst().getExpression();
+      assertThat(expression).contains(TENANT_1, TENANT_3);
+      assertThat(expression).doesNotContain(TENANT_2);
+    });
+
+    // Add tenant back
+    sendEntitlementEvent(MODULE_FOO_ID, TENANT_2, TenantEntitlementEvent.Type.ENTITLE);
+
+    await().atMost(TEN_SECONDS).untilAsserted(() -> {
+      var routes = kongAdminClient.getServiceRoutes(MODULE_FOO_ID, null);
+      var expression = routes.getData().getFirst().getExpression();
+      assertThat(expression).contains(TENANT_1, TENANT_2, TENANT_3);
+    });
+  }
+
+  @Test
+  @Sql(scripts = "classpath:/sql/module-discoveries-it.sql")
+  void entitlementEvent_negative_revokeNonExistentTenant() throws Exception {
+    // Create module discovery
+    createModuleDiscovery(MODULE_FOO_ID, MODULE_FOO_NAME, MODULE_FOO_VERSION, MODULE_FOO_URL);
+
+    // Add one tenant
+    sendEntitlementEvent(MODULE_FOO_ID, TENANT_1, TenantEntitlementEvent.Type.ENTITLE);
+
+    await().atMost(TEN_SECONDS).untilAsserted(() -> {
+      var routes = kongAdminClient.getServiceRoutes(MODULE_FOO_ID, null);
+      var expression = routes.getData().getFirst().getExpression();
+      assertThat(expression).contains(TENANT_1);
+    });
+
+    // Try to revoke tenant that doesn't exist - should be idempotent
+    sendEntitlementEvent(MODULE_FOO_ID, "non-existent-tenant", TenantEntitlementEvent.Type.REVOKE);
+
+    // Verify existing tenant still present
+    await().pollDelay(FIVE_SECONDS).atMost(TEN_SECONDS).untilAsserted(() -> {
+      var routes = kongAdminClient.getServiceRoutes(MODULE_FOO_ID, null);
+      var expression = routes.getData().getFirst().getExpression();
+      assertThat(expression).contains(TENANT_1);
+    });
+  }
+
+  @Test
+  @Sql(scripts = "classpath:/sql/module-discoveries-it.sql")
+  void entitlementEvent_positive_multipleRoutesPerModule() throws Exception {
+    // Create module discovery with multiple routes
+    createModuleDiscovery(MODULE_FOO_ID, MODULE_FOO_NAME, MODULE_FOO_VERSION, MODULE_FOO_URL);
+
+    // Verify initial routes - should have at least one route
+    var routesBefore = kongAdminClient.getServiceRoutes(MODULE_FOO_ID, null);
+    var routeCount = routesBefore.getData().size();
+    assertThat(routeCount).isGreaterThan(0);
+
+    // Send ENTITLE event
+    sendEntitlementEvent(MODULE_FOO_ID, TENANT_1, TenantEntitlementEvent.Type.ENTITLE);
+
+    // Verify all routes updated
+    await().atMost(TEN_SECONDS).untilAsserted(() -> {
+      var routes = kongAdminClient.getServiceRoutes(MODULE_FOO_ID, null);
+      assertThat(routes.getData()).hasSize(routeCount);
+      routes.getData().forEach(route -> {
+        assertThat(route.getExpression()).contains(TENANT_1);
+      });
+    });
+  }
+
+  private void sendEntitlementEvent(String moduleId, String tenantName,
+                                     TenantEntitlementEvent.Type type) {
+    var event = TenantEntitlementEvent.of(moduleId, tenantName, UUID.randomUUID(), type);
+    kafkaTemplate.send(entitlementTopic, event);
+  }
+
+  private void createModuleDiscovery(String moduleId, String moduleName,
+                                      String moduleVersion, String url) throws Exception {
+    var discovery = moduleDiscovery(moduleName, moduleVersion, url);
+    mockMvc.perform(post("/modules/{id}/discovery", moduleId)
+        .contentType(APPLICATION_JSON)
+        .header(OkapiHeaders.TOKEN, OKAPI_AUTH_TOKEN)
+        .content(asJsonString(discovery)))
+      .andExpect(status().isCreated());
+  }
+
+  private void deleteServiceSafely(String serviceId) {
+    try {
+      kongAdminClient.getServiceRoutes(serviceId, null)
+        .forEach(route -> kongAdminClient.deleteRoute(serviceId, route.getId()));
+    } catch (Exception e) {
+      // Ignore errors during cleanup
+    }
+
+    try {
+      kongAdminClient.deleteService(serviceId);
+    } catch (Exception e) {
+      // Ignore errors during cleanup
+    }
+  }
+}

--- a/src/test/java/org/folio/am/support/config/KafkaTestConfiguration.java
+++ b/src/test/java/org/folio/am/support/config/KafkaTestConfiguration.java
@@ -1,0 +1,65 @@
+package org.folio.am.support.config;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.kafka.config.TopicBuilder;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaAdmin;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+@TestConfiguration
+public class KafkaTestConfiguration {
+
+  @Value("${spring.kafka.bootstrap-servers:${KAFKA_HOST:localhost}:${KAFKA_PORT:9092}}")
+  private String bootstrapServers;
+
+  @Value("${kafka.topics.entitlement}")
+  private String entitlementTopic;
+
+  @Bean
+  public KafkaAdmin kafkaAdmin() {
+    Map<String, Object> configs = new HashMap<>();
+    configs.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+    return new KafkaAdmin(configs);
+  }
+
+  @Bean
+  public NewTopic entitlementTopic() {
+    return TopicBuilder.name(entitlementTopic)
+      .partitions(1)
+      .replicas(1)
+      .build();
+  }
+
+  @Bean
+  public ProducerFactory<String, String> stringProducerFactory() {
+    Map<String, Object> configProps = new HashMap<>();
+    configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+    configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+    configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+    return new DefaultKafkaProducerFactory<>(configProps);
+  }
+
+  @Bean
+  public ProducerFactory<String, Object> objectProducerFactory() {
+    Map<String, Object> configProps = new HashMap<>();
+    configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+    configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+    configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+    return new DefaultKafkaProducerFactory<>(configProps);
+  }
+
+  @Bean
+  public KafkaTemplate<String, Object> kafkaTemplate() {
+    return new KafkaTemplate<>(objectProducerFactory());
+  }
+}

--- a/src/test/resources/application-it.yml
+++ b/src/test/resources/application-it.yml
@@ -31,6 +31,9 @@ application:
       password: ${KC_ADMIN_CLIENT_SECRET}
   okapi:
     enabled: true
+  kong:
+    tenant-checks:
+      enabled: ${KONG_TENANT_CHECKS_ENABLED:false}
   secret-store:
     type: EPHEMERAL
     ephemeral:
@@ -39,5 +42,13 @@ application:
         folio_master_folio-backend-admin-client: ${KC_ADMIN_CLIENT_SECRET}
   validation:
     default-mode: basic
+  retry:
+    tenant-routes:
+      retry-delay: 250ms
+      retry-attempts: 5
 routemanagement:
   enable: true
+
+kafka:
+  topics:
+    entitlement: ${KAFKA_ENTITLEMENT_TOPIC:it.entitlement}


### PR DESCRIPTION
### Purpose

   Implement Kafka-based entitlement event consumption for dynamic tenant-specific route enforcement in Kong Gateway. This addresses the need to automatically update Kong routes based on tenant entitlement lifecycle events (ENTITLE, UPGRADE, REVOKE).

   Related issue: [MGRAPPS-70](https://folio-org.atlassian.net/browse/MGRAPPS-70) 

###    Approach

   The implementation adds a new entitlement event listener system that consumes Kafka events and dynamically updates Kong routes with tenant-specific validation:

   Core Components:

     - EntitlementEventListener: Kafka consumer that listens to entitlement events and triggers tenant route checks updates
     - EntitlementConsumerConfiguration: Configures Kafka consumer with JSON deserialization and error handling for entitlement topic
     - TenantRoutesRetryConfiguration: Implements retry logic (5 attempts, 250ms delay) for route update operations to handle transient failures
     - TenantEntitlementEvent: Domain model for entitlement events containing tenant, application, and entitlement type

   Route Management Logic:

     - ENTITLE/UPGRADE events: Adds tenant to route's x-okapi-tenant header validation expression
     - REVOKE events: Removes tenant from route's tenant-check clause
     - First tenant: Converts wildcard routes to explicit tenant-check expressions
     - Last tenant removal: Reverts routes back to wildcard (no restrictions)

   Configuration:

     - Feature toggle via KONG_TENANT_CHECKS_ENABLED (default: false)
     - Configurable Kafka topic via KAFKA_ENTITLEMENT_TOPIC (default: ${ENV}.entitlement)
     - Retry configuration for resilient route updates

   Testing:

     - Unit tests for listener, consumer configuration, and retry configuration
     - Integration tests covering all event types and edge cases (first/last tenant scenarios)
     - Kafka test configuration with embedded broker support


---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [x] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [x] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
