### PR TITLE
MGRAPPS-100: add cleanup endpoint for unused applications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ build/
 ### AI tools ###
 .claude/
 .codemie/
+CLAUDE.md

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@
 * Add API endpoint: Get Application Discovery By Query (MGRAPPS-98)
 * Migrate CI from Jenkins to GitHub Actions Maven central workflow (MGRAPPS-96)
 * Upgrade module to SpringBoot4.0 and Spring7.0 (MGRAPPS-102)
+* Add `cleanup` endpoint for unused Applications (MGRAPPS-100)
 ---
 
 ## Version `v3.0.0` (12.03.2025)

--- a/docs/features.md
+++ b/docs/features.md
@@ -6,3 +6,4 @@ This directory contains behavioral feature documentation for the Manager Applica
 
 - [kong-route-management](features/kong-route-management.md) - Kong Gateway Route Management
 - [Application Discovery](features/application-discovery.md) - Query module deployment locations organized by application
+- [Application Cleanup](features/application-cleanup.md) - Remove unused application descriptors and return a cleanup summary

--- a/docs/features/application-cleanup.md
+++ b/docs/features/application-cleanup.md
@@ -1,0 +1,44 @@
+---
+feature_id: application-cleanup
+title: Application Cleanup
+updated: 2026-04-14
+---
+
+# Application Cleanup
+
+## What it does
+Application Cleanup provides a bulk `POST /applications/cleanup` operation that inspects registered application descriptors and removes the ones that are not currently installed for any tenants. The endpoint returns a best-effort summary showing how many application descriptors were inspected, removed, skipped, or failed, plus the IDs in each category.
+
+## Why it exists
+Operators need a safe way to remove stale application descriptors without manually checking each application first. This feature reduces cleanup work while protecting application descriptors that are still actively installed for tenants.
+
+## Entry point(s)
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/applications/cleanup` | Removes application descriptors that are not installed for any tenants and returns a cleanup summary |
+
+## Business rules and constraints
+- The operation inspects every application descriptor ID currently stored in the `application` table.
+- Cleanup is best-effort: one deletion failure does not stop later application descriptors from being processed.
+- Application descriptors that still have tenant entitlements are skipped instead of being deleted.
+- The response always includes counts and ID lists for `cleaned`, `skipped`, and `failed` results.
+- Cleanup reuses the normal application deletion flow, so modules shared with other applications are retained while modules used only by the deleted application can be removed together with their discovery records.
+
+## Error behavior
+- `200 OK` is returned even when some application descriptors cannot be removed; those IDs are reported in `failedIds`.
+- Application descriptors that are still installed are not returned as HTTP conflicts during bulk cleanup; they are counted in `skipped` and listed in `skippedIds`.
+- `501 Not Implemented` is returned when the entitlement service is unavailable, including when FAR mode disables that integration.
+- `500 Internal Server Error` can still occur for request-level failures such as being unable to load application IDs before cleanup starts or other uncaught server errors.
+
+## Configuration
+| Variable | Purpose |
+|----------|---------|
+| `application.far-mode.enabled` | When `true`, disables the tenant-entitlement integration that cleanup depends on, so the endpoint returns `501 Not Implemented`. Maps to `FAR_MODE`. |
+| `tenant.entitlement.url` | Base URL for the tenant-entitlement service queried to determine whether an application is still installed. Maps to `TE_URL`. |
+| `tenant.entitlement.tls.enabled` | Enables TLS for tenant-entitlement requests used during cleanup. Maps to `TE_TLS_ENABLED`. |
+
+## Dependencies and interactions
+- Depends on `mgr-tenant-entitlements` `GET /entitlements` queries filtered by `applicationId=<id>` to determine whether an application descriptor can be deleted.
+- When `application.okapi.enabled` is enabled, removing an unused application descriptor also deletes Okapi module descriptors that are no longer referenced and removes Okapi discovery records for deleted module instances.
+- When `application.kong.enabled` is enabled and a removed backend module has discovery information, cleanup-triggered discovery deletion removes the corresponding Kong service.
+- When both `application.kong.enabled` and `routemanagement.enable` are enabled, the same cleanup flow also deletes that Kong service's routes before deleting the service.

--- a/src/main/java/org/folio/am/controller/ApiExceptionHandler.java
+++ b/src/main/java/org/folio/am/controller/ApiExceptionHandler.java
@@ -24,6 +24,7 @@ import jakarta.validation.ConstraintViolationException;
 import java.util.Optional;
 import lombok.extern.log4j.Log4j2;
 import org.apache.logging.log4j.Level;
+import org.folio.am.exception.ApplicationInstalledException;
 import org.folio.am.exception.RequestValidationException;
 import org.folio.am.exception.ServiceException;
 import org.folio.common.domain.model.error.Error;
@@ -125,6 +126,12 @@ public class ApiExceptionHandler {
    */
   @ExceptionHandler(EntityExistsException.class)
   public ResponseEntity<ErrorResponse> handleEntityExistsException(EntityExistsException exception) {
+    return buildResponseEntity(exception, CONFLICT, FOUND_ERROR);
+  }
+
+  @ExceptionHandler(ApplicationInstalledException.class)
+  public ResponseEntity<ErrorResponse> handleApplicationInstalledException(
+    ApplicationInstalledException exception) {
     return buildResponseEntity(exception, CONFLICT, FOUND_ERROR);
   }
 

--- a/src/main/java/org/folio/am/controller/ApplicationController.java
+++ b/src/main/java/org/folio/am/controller/ApplicationController.java
@@ -5,6 +5,7 @@ import static org.springframework.http.HttpStatus.CREATED;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.folio.am.domain.dto.ApplicationCleanupResult;
 import org.folio.am.domain.dto.ApplicationDescriptor;
 import org.folio.am.domain.dto.ApplicationDescriptors;
 import org.folio.am.domain.dto.ApplicationDescriptorsValidation;
@@ -12,6 +13,7 @@ import org.folio.am.domain.dto.ApplicationReferences;
 import org.folio.am.domain.dto.ValidationMode;
 import org.folio.am.domain.model.ValidationContext;
 import org.folio.am.rest.resource.ApplicationsApi;
+import org.folio.am.service.ApplicationCleanupService;
 import org.folio.am.service.ApplicationDescriptorsValidationService;
 import org.folio.am.service.ApplicationReferencesValidationService;
 import org.folio.am.service.ApplicationService;
@@ -27,6 +29,7 @@ public class ApplicationController extends BaseController implements Application
   private final ApplicationValidatorService applicationValidatorService;
   private final ApplicationReferencesValidationService applicationReferencesValidationService;
   private final ApplicationDescriptorsValidationService applicationDescriptorsValidationService;
+  private final ApplicationCleanupService applicationCleanupService;
   private final ApplicationService applicationService;
 
   @Override
@@ -62,6 +65,11 @@ public class ApplicationController extends BaseController implements Application
   public ResponseEntity<Void> deregisterApplicationById(String id, String token) {
     applicationService.delete(id, token);
     return ResponseEntity.noContent().build();
+  }
+
+  @Override
+  public ResponseEntity<ApplicationCleanupResult> cleanupApplications(String token) {
+    return ResponseEntity.ok(applicationCleanupService.cleanup(token));
   }
 
   @Override

--- a/src/main/java/org/folio/am/exception/ApplicationInstalledException.java
+++ b/src/main/java/org/folio/am/exception/ApplicationInstalledException.java
@@ -1,0 +1,8 @@
+package org.folio.am.exception;
+
+public class ApplicationInstalledException extends RuntimeException {
+
+  public ApplicationInstalledException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/org/folio/am/repository/ApplicationRepository.java
+++ b/src/main/java/org/folio/am/repository/ApplicationRepository.java
@@ -56,4 +56,7 @@ public interface ApplicationRepository extends JpaCqlRepository<ApplicationEntit
 
   @Query(value = "SELECT a.id, a.name, a.version FROM application a WHERE a.name = :name", nativeQuery = true)
   List<ApplicationProjection> findAllAppArtifactsByName(String name);
+
+  @Query(value = "SELECT a.id FROM application a", nativeQuery = true)
+  List<String> findAllApplicationIds();
 }

--- a/src/main/java/org/folio/am/service/ApplicationCleanupService.java
+++ b/src/main/java/org/folio/am/service/ApplicationCleanupService.java
@@ -3,7 +3,6 @@ package org.folio.am.service;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import lombok.Setter;
 import lombok.extern.log4j.Log4j2;
 import org.folio.am.domain.dto.ApplicationCleanupResult;
 import org.folio.am.exception.ApplicationInstalledException;
@@ -20,7 +19,7 @@ public class ApplicationCleanupService {
   private final ApplicationRepository applicationRepository;
   private final ApplicationService applicationService;
 
-  @Setter(onMethod_ = @Autowired(required = false))
+  @Autowired(required = false)
   private EntitlementService entitlementService;
 
   public ApplicationCleanupResult cleanup(String token) {

--- a/src/main/java/org/folio/am/service/ApplicationCleanupService.java
+++ b/src/main/java/org/folio/am/service/ApplicationCleanupService.java
@@ -8,7 +8,6 @@ import org.folio.am.domain.dto.ApplicationCleanupResult;
 import org.folio.am.exception.ApplicationInstalledException;
 import org.folio.am.integration.mte.EntitlementService;
 import org.folio.am.repository.ApplicationRepository;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Log4j2
@@ -18,9 +17,7 @@ public class ApplicationCleanupService {
 
   private final ApplicationRepository applicationRepository;
   private final ApplicationService applicationService;
-
-  @Autowired(required = false)
-  private EntitlementService entitlementService;
+  private final EntitlementService entitlementService;
 
   public ApplicationCleanupResult cleanup(String token) {
     ensureCleanupSupported();

--- a/src/main/java/org/folio/am/service/ApplicationCleanupService.java
+++ b/src/main/java/org/folio/am/service/ApplicationCleanupService.java
@@ -8,6 +8,7 @@ import org.folio.am.domain.dto.ApplicationCleanupResult;
 import org.folio.am.exception.ApplicationInstalledException;
 import org.folio.am.integration.mte.EntitlementService;
 import org.folio.am.repository.ApplicationRepository;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Log4j2
@@ -17,7 +18,9 @@ public class ApplicationCleanupService {
 
   private final ApplicationRepository applicationRepository;
   private final ApplicationService applicationService;
-  private final EntitlementService entitlementService;
+
+  @Autowired(required = false)
+  private EntitlementService entitlementService;
 
   public ApplicationCleanupResult cleanup(String token) {
     ensureCleanupSupported();
@@ -37,8 +40,8 @@ public class ApplicationCleanupService {
     return applicationRepository.findAllApplicationIds();
   }
 
-  private void cleanupApplication(String id, String token, ArrayList<String> cleanedIds,
-    ArrayList<String> skippedIds, ArrayList<String> failedIds) {
+  private void cleanupApplication(String id, String token, List<String> cleanedIds, List<String> skippedIds,
+    List<String> failedIds) {
     try {
       applicationService.delete(id, token);
       cleanedIds.add(id);
@@ -51,8 +54,8 @@ public class ApplicationCleanupService {
     }
   }
 
-  private static ApplicationCleanupResult buildResult(int inspected, ArrayList<String> cleanedIds,
-    ArrayList<String> skippedIds, ArrayList<String> failedIds) {
+  private static ApplicationCleanupResult buildResult(int inspected, List<String> cleanedIds, List<String> skippedIds,
+    List<String> failedIds) {
     return new ApplicationCleanupResult()
       .inspected(inspected)
       .cleaned(cleanedIds.size())

--- a/src/main/java/org/folio/am/service/ApplicationCleanupService.java
+++ b/src/main/java/org/folio/am/service/ApplicationCleanupService.java
@@ -1,0 +1,76 @@
+package org.folio.am.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.extern.log4j.Log4j2;
+import org.folio.am.domain.dto.ApplicationCleanupResult;
+import org.folio.am.exception.ApplicationInstalledException;
+import org.folio.am.integration.mte.EntitlementService;
+import org.folio.am.repository.ApplicationRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Log4j2
+@Service
+@RequiredArgsConstructor
+public class ApplicationCleanupService {
+
+  private final ApplicationRepository applicationRepository;
+  private final ApplicationService applicationService;
+
+  @Setter(onMethod_ = @Autowired(required = false))
+  private EntitlementService entitlementService;
+
+  public ApplicationCleanupResult cleanup(String token) {
+    ensureCleanupSupported();
+    var ids = loadAllApplicationIds();
+    var cleanedIds = new ArrayList<String>();
+    var skippedIds = new ArrayList<String>();
+    var failedIds = new ArrayList<String>();
+
+    for (var id : ids) {
+      cleanupApplication(id, token, cleanedIds, skippedIds, failedIds);
+    }
+
+    return buildResult(ids.size(), cleanedIds, skippedIds, failedIds);
+  }
+
+  private List<String> loadAllApplicationIds() {
+    return applicationRepository.findAllApplicationIds();
+  }
+
+  private void cleanupApplication(String id, String token, ArrayList<String> cleanedIds,
+    ArrayList<String> skippedIds, ArrayList<String> failedIds) {
+    try {
+      applicationService.delete(id, token);
+      cleanedIds.add(id);
+    } catch (ApplicationInstalledException e) {
+      skippedIds.add(id);
+      log.debug("Application is installed, skipping cleanup: id = {}", id);
+    } catch (Exception e) {
+      failedIds.add(id);
+      log.warn("Failed to cleanup application: id = {}", id, e);
+    }
+  }
+
+  private static ApplicationCleanupResult buildResult(int inspected, ArrayList<String> cleanedIds,
+    ArrayList<String> skippedIds, ArrayList<String> failedIds) {
+    return new ApplicationCleanupResult()
+      .inspected(inspected)
+      .cleaned(cleanedIds.size())
+      .skipped(skippedIds.size())
+      .failed(failedIds.size())
+      .cleanedIds(cleanedIds)
+      .skippedIds(skippedIds)
+      .failedIds(failedIds);
+  }
+
+  private void ensureCleanupSupported() {
+    if (entitlementService == null) {
+      throw new UnsupportedOperationException(
+        "Applications cleanup is not supported: entitlement service is not available");
+    }
+  }
+}

--- a/src/main/java/org/folio/am/service/ApplicationService.java
+++ b/src/main/java/org/folio/am/service/ApplicationService.java
@@ -2,7 +2,6 @@ package org.folio.am.service;
 
 import static java.util.Objects.isNull;
 import static java.util.function.Function.identity;
-import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 import static org.apache.commons.collections4.CollectionUtils.isEmpty;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
@@ -88,7 +87,7 @@ public class ApplicationService {
   public List<ApplicationDescriptor> findByIds(List<String> ids, boolean includeModuleDescriptors) {
     return appRepository.findByIds(ids).stream()
       .map(descriptorWithModules(includeModuleDescriptors))
-      .collect(toList());
+      .toList();
   }
 
   /**
@@ -228,7 +227,7 @@ public class ApplicationService {
   public List<ApplicationDescriptor> findApplicationsByModuleIds(List<String> moduleIds) {
     return appRepository.findApplicationsByModuleIds(moduleIds).stream()
       .map(ApplicationEntity::getApplicationDescriptor)
-      .collect(toList());
+      .toList();
   }
 
   public List<String> findAllApplicationIdsByName(String applicationName) {

--- a/src/main/java/org/folio/am/service/ApplicationService.java
+++ b/src/main/java/org/folio/am/service/ApplicationService.java
@@ -32,6 +32,7 @@ import org.folio.am.domain.entity.ApplicationEntity;
 import org.folio.am.domain.entity.ApplicationProjection;
 import org.folio.am.domain.entity.ModuleEntity;
 import org.folio.am.domain.model.ValidationContext;
+import org.folio.am.exception.ApplicationInstalledException;
 import org.folio.am.integration.mte.EntitlementService;
 import org.folio.am.mapper.ApplicationDescriptorMapper;
 import org.folio.am.repository.ApplicationRepository;
@@ -278,7 +279,7 @@ public class ApplicationService {
     if (entitlementService != null) {
       var tenants = entitlementService.getTenants(id, token);
       if (isNotEmpty(tenants)) {
-        throw new EntityExistsException("Application Descriptor cannot be removed "
+        throw new ApplicationInstalledException("Application Descriptor cannot be removed "
           + "because it is installed for tenants: " + tenants);
       }
     }

--- a/src/main/resources/descriptors/ModuleDescriptor.json
+++ b/src/main/resources/descriptors/ModuleDescriptor.json
@@ -34,6 +34,13 @@
         {
           "type": "internal",
           "methods": [ "POST" ],
+          "pathPattern": "/applications/cleanup",
+          "permissionsRequired": [ "mgr-applications.applications.collection.cleanup" ],
+          "modulePermissions": [ "mgr-tenant-entitlements.entitlements.collection.get" ]
+        },
+        {
+          "type": "internal",
+          "methods": [ "POST" ],
           "pathPattern": "/applications/validate",
           "permissionsRequired": [ "mgr-applications.applications.item.validate" ]
         },
@@ -173,6 +180,14 @@
       "permissionName": "mgr-applications.applications.collection.get"
     },
     {
+      "description": "Cleanup unused application descriptors",
+      "displayName": "Manager Applications - cleanup applications",
+      "permissionName": "mgr-applications.applications.collection.cleanup",
+      "subPermissions": [
+        "mgr-tenant-entitlements.entitlements.collection.get"
+      ]
+    },
+    {
       "description": "Register new module discoveries for application",
       "displayName": "Manager Applications - create discoveries",
       "permissionName": "mgr-applications.discoveries.collection.post",
@@ -256,7 +271,8 @@
         "mgr-applications.applications.collection.validate-dependencies",
         "mgr-applications.applications.item.get",
         "mgr-applications.applications.item.delete",
-        "mgr-applications.applications.collection.get"
+        "mgr-applications.applications.collection.get",
+        "mgr-applications.applications.collection.cleanup"
       ]
     },
     {

--- a/src/main/resources/swagger.api/am.yaml
+++ b/src/main/resources/swagger.api/am.yaml
@@ -63,6 +63,30 @@ paths:
         '500':
           $ref: '#/components/responses/internal-server-error'
 
+  /applications/cleanup:
+    post:
+      operationId: cleanupApplications
+      description: Remove unused application descriptors and return a best-effort cleanup summary.
+      tags:
+        - applications
+      parameters:
+        - $ref: '#/components/parameters/x-okapi-token'
+      responses:
+        '200':
+          description: Applications cleanup summary
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/applicationCleanupResult'
+        '501':
+          description: Applications cleanup is not supported in FAR mode
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorResponse'
+        '500':
+          $ref: '#/components/responses/internal-server-error'
+
   /applications/{id}:
     get:
       operationId: getApplicationById
@@ -364,6 +388,8 @@ components:
       $ref: schemas/applicationDescriptorsValidation.json
     applicationDescriptor:
       $ref: schemas/applicationDescriptor.json
+    applicationCleanupResult:
+      $ref: schemas/applicationCleanupResult.json
     applicationDescriptors:
       $ref: schemas/applicationDescriptors.json
     applicationDiscovery:
@@ -520,4 +546,3 @@ components:
         enum: [ id, version ]
         default: version
       example: version
-

--- a/src/main/resources/swagger.api/schemas/applicationCleanupResult.json
+++ b/src/main/resources/swagger.api/schemas/applicationCleanupResult.json
@@ -1,36 +1,44 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
+  "description": "Summary of the application cleanup execution",
   "properties": {
     "inspected": {
+      "description": "The total number of application descriptors inspected for cleanup",
       "type": "integer",
       "minimum": 0
     },
     "cleaned": {
+      "description": "The number of application descriptors removed successfully",
       "type": "integer",
       "minimum": 0
     },
     "skipped": {
+      "description": "The number of application descriptors skipped because they are still installed",
       "type": "integer",
       "minimum": 0
     },
     "failed": {
+      "description": "The number of application descriptors that could not be removed due to errors",
       "type": "integer",
       "minimum": 0
     },
     "cleanedIds": {
+      "description": "The identifiers of application descriptors removed successfully",
       "type": "array",
       "items": {
         "type": "string"
       }
     },
     "skippedIds": {
+      "description": "The identifiers of application descriptors skipped because they are still installed",
       "type": "array",
       "items": {
         "type": "string"
       }
     },
     "failedIds": {
+      "description": "The identifiers of application descriptors that failed cleanup",
       "type": "array",
       "items": {
         "type": "string"

--- a/src/main/resources/swagger.api/schemas/applicationCleanupResult.json
+++ b/src/main/resources/swagger.api/schemas/applicationCleanupResult.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "inspected": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "cleaned": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "skipped": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "failed": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "cleanedIds": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "skippedIds": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "failedIds": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "required": [
+    "inspected",
+    "cleaned",
+    "skipped",
+    "failed",
+    "cleanedIds",
+    "skippedIds",
+    "failedIds"
+  ]
+}

--- a/src/test/java/org/folio/am/controller/ApplicationControllerTest.java
+++ b/src/test/java/org/folio/am/controller/ApplicationControllerTest.java
@@ -32,10 +32,12 @@ import java.util.List;
 import java.util.UUID;
 import lombok.extern.log4j.Log4j2;
 import org.eclipse.microprofile.jwt.JsonWebToken;
+import org.folio.am.domain.dto.ApplicationCleanupResult;
 import org.folio.am.domain.dto.ApplicationDescriptor;
 import org.folio.am.domain.dto.ApplicationDescriptors;
 import org.folio.am.domain.dto.ApplicationDescriptorsValidation;
 import org.folio.am.domain.dto.Dependency;
+import org.folio.am.service.ApplicationCleanupService;
 import org.folio.am.service.ApplicationDescriptorsValidationService;
 import org.folio.am.service.ApplicationReferencesValidationService;
 import org.folio.am.service.ApplicationService;
@@ -81,6 +83,7 @@ class ApplicationControllerTest {
   @Mock private JsonWebToken jsonWebToken;
   @MockitoBean private KeycloakAuthClient authClient;
   @MockitoBean private JsonWebTokenParser jsonWebTokenParser;
+  @MockitoBean private ApplicationCleanupService applicationCleanupService;
   @MockitoBean private ApplicationValidatorService applicationValidatorService;
   @MockitoBean private ApplicationService applicationService;
   @MockitoBean private ApplicationReferencesValidationService applicationReferencesValidationService;
@@ -397,6 +400,55 @@ class ApplicationControllerTest {
     mockMvc.perform(delete("/applications/{id}", APPLICATION_ID)
         .contentType(APPLICATION_JSON))
       .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  void cleanup_positive_returnsBestEffortSummary() throws Exception {
+    var cleanupResult = new ApplicationCleanupResult()
+      .inspected(2)
+      .cleaned(1)
+      .skipped(1)
+      .failed(0)
+      .cleanedIds(List.of("app-a-1.0.0"))
+      .skippedIds(List.of("app-b-1.0.0"))
+      .failedIds(emptyList());
+
+    when(jsonWebTokenParser.parse(OKAPI_AUTH_TOKEN)).thenReturn(jsonWebToken);
+    when(jsonWebToken.getIssuer()).thenReturn(TOKEN_ISSUER);
+    when(jsonWebToken.getSubject()).thenReturn(TOKEN_SUB);
+    when(applicationCleanupService.cleanup(OKAPI_AUTH_TOKEN)).thenReturn(cleanupResult);
+
+    mockMvc.perform(post("/applications/cleanup")
+        .contentType(APPLICATION_JSON)
+        .header(OkapiHeaders.TOKEN, OKAPI_AUTH_TOKEN))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.inspected", is(2)))
+      .andExpect(jsonPath("$.cleaned", is(1)))
+      .andExpect(jsonPath("$.skipped", is(1)))
+      .andExpect(jsonPath("$.failed", is(0)))
+      .andExpect(jsonPath("$.cleanedIds[0]", is("app-a-1.0.0")))
+      .andExpect(jsonPath("$.skippedIds[0]", is("app-b-1.0.0")))
+      .andExpect(jsonPath("$.failedIds", is(emptyList())));
+  }
+
+  @Test
+  void cleanup_negative_farModeIsNotSupported() throws Exception {
+    when(jsonWebTokenParser.parse(OKAPI_AUTH_TOKEN)).thenReturn(jsonWebToken);
+    when(jsonWebToken.getIssuer()).thenReturn(TOKEN_ISSUER);
+    when(jsonWebToken.getSubject()).thenReturn(TOKEN_SUB);
+    when(applicationCleanupService.cleanup(OKAPI_AUTH_TOKEN))
+      .thenThrow(new UnsupportedOperationException(
+        "Applications cleanup is not supported: entitlement service is not available"));
+
+    mockMvc.perform(post("/applications/cleanup")
+        .contentType(APPLICATION_JSON)
+        .header(OkapiHeaders.TOKEN, OKAPI_AUTH_TOKEN))
+      .andExpect(status().isNotImplemented())
+      .andExpect(jsonPath("$.total_records", is(1)))
+      .andExpect(jsonPath("$.errors[0].message",
+        is("Applications cleanup is not supported: entitlement service is not available")))
+      .andExpect(jsonPath("$.errors[0].type", is("UnsupportedOperationException")))
+      .andExpect(jsonPath("$.errors[0].code", is("service_error")));
   }
 
   @Test

--- a/src/test/java/org/folio/am/it/ApplicationCleanupIT.java
+++ b/src/test/java/org/folio/am/it/ApplicationCleanupIT.java
@@ -1,0 +1,84 @@
+package org.folio.am.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.folio.am.integration.kafka.DiscoveryPublisher.DISCOVERY_DESTINATION;
+import static org.folio.am.support.TestUtils.generateAccessToken;
+import static org.folio.integration.kafka.KafkaUtils.getEnvTopicName;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_METHOD;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Set;
+import org.folio.am.domain.entity.ArtifactEntity;
+import org.folio.am.integration.kafka.model.DiscoveryEvent;
+import org.folio.am.repository.ModuleRepository;
+import org.folio.am.support.KafkaEventAssertions;
+import org.folio.am.support.base.BaseIntegrationTest;
+import org.folio.security.integration.keycloak.configuration.properties.KeycloakProperties;
+import org.folio.test.extensions.EnableKeycloakDataImport;
+import org.folio.test.extensions.EnableKeycloakSecurity;
+import org.folio.test.extensions.EnableKeycloakTlsMode;
+import org.folio.test.extensions.WireMockStub;
+import org.folio.test.types.IntegrationTest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.jdbc.Sql;
+
+@IntegrationTest
+@EnableKeycloakSecurity
+@EnableKeycloakTlsMode
+@EnableKeycloakDataImport
+@Sql(scripts = "classpath:/sql/application-cleanup.sql", executionPhase = BEFORE_TEST_METHOD)
+@Sql(scripts = "classpath:/sql/truncate-tables.sql", executionPhase = AFTER_TEST_METHOD)
+class ApplicationCleanupIT extends BaseIntegrationTest {
+
+  private static final String CLEANED_APPLICATION_ID = "test-app-1.0.0";
+  private static final String SKIPPED_APPLICATION_ID = "test-app-2.0.0";
+  private static final String CLEANED_MODULE_ID = "mod-bar-1.0.0";
+  private static final String SHARED_MODULE_ID = "mod-foo-1.0.0";
+  private static final String SKIPPED_MODULE_ID = "mod-bar-1.0.1";
+
+  @Autowired private ModuleRepository moduleRepository;
+  @Autowired private KeycloakProperties keycloakProperties;
+
+  @BeforeAll
+  static void setUp() {
+    fakeKafkaConsumer.registerTopic(getEnvTopicName(DISCOVERY_DESTINATION), DiscoveryEvent.class);
+  }
+
+  @Test
+  @WireMockStub(scripts = "/wiremock/stubs/mte/get-entitlement-application-cleanup-not-installed.json")
+  @WireMockStub(scripts = "/wiremock/stubs/mte/get-entitlement-application-cleanup.json")
+  @WireMockStub(scripts = "/wiremock/stubs/okapi/application/delete-mod-bar-1.0.0.json")
+  @WireMockStub(scripts = "/wiremock/stubs/okapi/application-discovery/delete-module-bar-discovery.json")
+  void cleanup_positive_removesUnusedAppsAndSkipsEntitledApps() throws Exception {
+    mockMvc.perform(post("/applications/cleanup")
+        .header(TOKEN, generateAccessToken(keycloakProperties)))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.inspected", is(2)))
+      .andExpect(jsonPath("$.cleaned", is(1)))
+      .andExpect(jsonPath("$.skipped", is(1)))
+      .andExpect(jsonPath("$.failed", is(0)))
+      .andExpect(jsonPath("$.cleanedIds", contains(CLEANED_APPLICATION_ID)))
+      .andExpect(jsonPath("$.skippedIds", contains(SKIPPED_APPLICATION_ID)))
+      .andExpect(jsonPath("$.failedIds", empty()));
+
+    doGet(get("/applications").queryParam("query", "cql.allRecords=1"))
+      .andExpect(jsonPath("$.totalRecords", is(1)))
+      .andExpect(jsonPath("$.applicationDescriptors[0].id", is(SKIPPED_APPLICATION_ID)));
+
+    var found = moduleRepository.findAllById(Set.of(CLEANED_MODULE_ID, SHARED_MODULE_ID, SKIPPED_MODULE_ID));
+    assertThat(found).hasSize(2)
+      .extracting(ArtifactEntity::getId)
+      .containsExactlyInAnyOrder(SHARED_MODULE_ID, SKIPPED_MODULE_ID);
+
+    KafkaEventAssertions.assertDiscoveryEvents(CLEANED_MODULE_ID);
+  }
+}

--- a/src/test/java/org/folio/am/it/ApplicationFarModeIT.java
+++ b/src/test/java/org/folio/am/it/ApplicationFarModeIT.java
@@ -9,7 +9,9 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_METHOD;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.List;
 import org.folio.am.domain.dto.ApplicationDescriptor;
@@ -41,6 +43,17 @@ class ApplicationFarModeIT extends BaseIntegrationTest {
     doDelete("/applications/{id}", APPLICATION_ID);
     doGet(get("/applications").queryParam("query", "cql.allRecords=1"))
       .andExpect(jsonPath("$.totalRecords", is(3)));
+  }
+
+  @Test
+  void cleanup_negative_farModeIsNotSupported() throws Exception {
+    mockMvc.perform(post("/applications/cleanup"))
+      .andExpect(status().isNotImplemented())
+      .andExpect(jsonPath("$.total_records", is(1)))
+      .andExpect(jsonPath("$.errors[0].message",
+        is("Applications cleanup is not supported: entitlement service is not available")))
+      .andExpect(jsonPath("$.errors[0].type", is("UnsupportedOperationException")))
+      .andExpect(jsonPath("$.errors[0].code", is("service_error")));
   }
 
   @Test

--- a/src/test/java/org/folio/am/it/KongRegistrationIT.java
+++ b/src/test/java/org/folio/am/it/KongRegistrationIT.java
@@ -33,6 +33,6 @@ class KongRegistrationIT extends BaseIntegrationTest {
     });
 
     var routes = kongAdminClient.getRoutesByTag(moduleName, null);
-    assertThat(routes.getData()).hasSize(17);
+    assertThat(routes.getData()).hasSize(18);
   }
 }

--- a/src/test/java/org/folio/am/service/ApplicationCleanupServiceTest.java
+++ b/src/test/java/org/folio/am/service/ApplicationCleanupServiceTest.java
@@ -1,0 +1,80 @@
+package org.folio.am.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.folio.am.exception.ApplicationInstalledException;
+import org.folio.am.integration.mte.EntitlementService;
+import org.folio.am.repository.ApplicationRepository;
+import org.folio.test.types.UnitTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@UnitTest
+@ExtendWith(MockitoExtension.class)
+class ApplicationCleanupServiceTest {
+
+  @InjectMocks private ApplicationCleanupService service;
+  @Mock private ApplicationRepository applicationRepository;
+  @Mock private ApplicationService applicationService;
+  @Mock private EntitlementService entitlementService;
+
+  @BeforeEach
+  void setUp() {
+    ReflectionTestUtils.setField(service, "entitlementService", entitlementService);
+  }
+
+  @Test
+  void cleanup_positive_collectsCleanedSkippedAndFailedIds() {
+    when(applicationRepository.findAllApplicationIds()).thenReturn(List.of(
+      "app-a-1.0.0", "app-b-1.0.0", "app-c-1.0.0"
+    ));
+    doAnswer(invocation -> {
+      var id = invocation.getArgument(0, String.class);
+      if ("app-b-1.0.0".equals(id)) {
+        throw new ApplicationInstalledException("Application is installed for tenants: [tenant-a]");
+      }
+      if ("app-c-1.0.0".equals(id)) {
+        throw new IllegalStateException("cleanup failed");
+      }
+      return null;
+    }).when(applicationService).delete(anyString(), eq("token"));
+
+    var result = service.cleanup("token");
+
+    assertThat(result.getInspected()).isEqualTo(3);
+    assertThat(result.getCleaned()).isEqualTo(1);
+    assertThat(result.getSkipped()).isEqualTo(1);
+    assertThat(result.getFailed()).isEqualTo(1);
+    assertThat(result.getCleanedIds()).containsExactly("app-a-1.0.0");
+    assertThat(result.getSkippedIds()).containsExactly("app-b-1.0.0");
+    assertThat(result.getFailedIds()).containsExactly("app-c-1.0.0");
+
+    verify(applicationService).delete("app-a-1.0.0", "token");
+    verify(applicationService).delete("app-b-1.0.0", "token");
+    verify(applicationService).delete("app-c-1.0.0", "token");
+  }
+
+  @Test
+  void cleanup_negative_entitlementServiceIsNotAvailable() {
+    ReflectionTestUtils.setField(service, "entitlementService", null);
+
+    assertThatThrownBy(() -> service.cleanup("token"))
+      .isInstanceOf(UnsupportedOperationException.class)
+      .hasMessage("Applications cleanup is not supported: entitlement service is not available");
+
+    verifyNoInteractions(applicationRepository, applicationService);
+  }
+}

--- a/src/test/java/org/folio/am/service/ApplicationServiceTest.java
+++ b/src/test/java/org/folio/am/service/ApplicationServiceTest.java
@@ -32,6 +32,7 @@ import org.folio.am.domain.dto.Module;
 import org.folio.am.domain.entity.ApplicationProjection;
 import org.folio.am.domain.entity.ArtifactEntity;
 import org.folio.am.domain.entity.ModuleEntity;
+import org.folio.am.exception.ApplicationInstalledException;
 import org.folio.am.integration.mte.EntitlementService;
 import org.folio.am.mapper.ApplicationDescriptorMapper;
 import org.folio.am.repository.ApplicationRepository;
@@ -65,12 +66,12 @@ class ApplicationServiceTest {
   @Mock private ApplicationDescriptorMapper mapper;
   @Mock private ApplicationEventPublisher eventPublisher;
   @Mock private ModuleDiscoveryService discoveryService;
-  @Mock private EntitlementService entitlementService;
   @Mock private ApplicationValidatorService applicationValidatorService;
   @Mock private ModuleDescriptorLoader moduleDescriptorLoader;
+  @Mock private EntitlementService entitlementService;
 
   @BeforeEach
-  public void init() {
+  void setUp() {
     service.setEntitlementService(entitlementService);
   }
 
@@ -230,10 +231,9 @@ class ApplicationServiceTest {
   }
 
   @Test
-  void delete_positive() {
+  void delete_positive_applicationAndModulesAreRemoved() {
     var expectedEntityToDelete = TestValues.applicationDescriptorEntity(descriptorWithSeveralModules());
     when(repository.findById(APPLICATION_ID)).thenReturn(Optional.of(expectedEntityToDelete));
-
     when(entitlementService.getTenants(APPLICATION_ID, OKAPI_AUTH_TOKEN)).thenReturn(List.of());
     expectedEntityToDelete.getModules().forEach(module -> {
       when(repository.existsByNotIdAndModuleId(expectedEntityToDelete.getId(), module.getId())).thenReturn(false);
@@ -244,16 +244,18 @@ class ApplicationServiceTest {
     service.delete(APPLICATION_ID, OKAPI_AUTH_TOKEN);
 
     verify(repository).delete(expectedEntityToDelete);
-
+    expectedEntityToDelete.getModules().forEach(module -> {
+      verify(discoveryService).delete(module.getId(), OKAPI_AUTH_TOKEN);
+      verify(moduleRepository).delete(module);
+    });
     verify(eventPublisher).publishDescriptorDelete(expectedEntityToDelete.getApplicationDescriptor(), OKAPI_AUTH_TOKEN);
   }
 
   @Test
-  void delete_positive_teIntegrationDisabled() {
+  void delete_positive_tenantEntitlementsIntegrationDisabled() {
     service.setEntitlementService(null);
     var expectedEntityToDelete = TestValues.applicationDescriptorEntity(descriptorWithSeveralModules());
     when(repository.findById(APPLICATION_ID)).thenReturn(Optional.of(expectedEntityToDelete));
-
     expectedEntityToDelete.getModules().forEach(module -> {
       when(repository.existsByNotIdAndModuleId(expectedEntityToDelete.getId(), module.getId())).thenReturn(false);
       doNothing().when(discoveryService).delete(module.getId(), OKAPI_AUTH_TOKEN);
@@ -263,16 +265,14 @@ class ApplicationServiceTest {
     service.delete(APPLICATION_ID, OKAPI_AUTH_TOKEN);
 
     verify(repository).delete(expectedEntityToDelete);
-
     verify(eventPublisher).publishDescriptorDelete(expectedEntityToDelete.getApplicationDescriptor(), OKAPI_AUTH_TOKEN);
     verifyNoInteractions(entitlementService);
   }
 
   @Test
-  void delete_positive_modulesBelongToOtherApp() {
+  void delete_positive_relatedModulesArePreserved() {
     var expectedEntityToDelete = TestValues.applicationDescriptorEntity(descriptorWithSeveralModules());
     when(repository.findById(APPLICATION_ID)).thenReturn(Optional.of(expectedEntityToDelete));
-
     when(entitlementService.getTenants(APPLICATION_ID, OKAPI_AUTH_TOKEN)).thenReturn(List.of());
     expectedEntityToDelete.getModules().forEach(module ->
       when(repository.existsByNotIdAndModuleId(expectedEntityToDelete.getId(), module.getId())).thenReturn(true));
@@ -280,49 +280,27 @@ class ApplicationServiceTest {
     service.delete(APPLICATION_ID, OKAPI_AUTH_TOKEN);
 
     verify(repository).delete(expectedEntityToDelete);
-
     verify(eventPublisher).publishDescriptorDelete(expectedEntityToDelete.getApplicationDescriptor(), OKAPI_AUTH_TOKEN);
+    verifyNoInteractions(discoveryService, moduleRepository);
   }
 
   @Test
-  void delete_positive_uiModulesBelongToOtherApp() {
-    var expectedEntityToDelete = TestValues.applicationDescriptorEntity(descriptorWithSeveralModules());
-    when(repository.findById(APPLICATION_ID)).thenReturn(Optional.of(expectedEntityToDelete));
-
-    when(entitlementService.getTenants(APPLICATION_ID, OKAPI_AUTH_TOKEN)).thenReturn(List.of());
-    expectedEntityToDelete.getModules().forEach(module -> {
-      when(repository.existsByNotIdAndModuleId(expectedEntityToDelete.getId(), module.getId()))
-        .thenReturn(false);
-      doNothing().when(discoveryService).delete(module.getId(), OKAPI_AUTH_TOKEN);
-      doNothing().when(moduleRepository).delete(module);
-    });
-
-    service.delete(APPLICATION_ID, OKAPI_AUTH_TOKEN);
-
-    verify(repository).delete(expectedEntityToDelete);
-
-    verify(eventPublisher).publishDescriptorDelete(expectedEntityToDelete.getApplicationDescriptor(), OKAPI_AUTH_TOKEN);
-  }
-
-  @Test
-  void delete_negative_entityNotFound() {
-    assertThatThrownBy(() -> service.delete(APPLICATION_ID, OKAPI_AUTH_TOKEN))
-      .isInstanceOf(EntityNotFoundException.class)
-      .hasMessage("Unable to find application descriptor with id " + APPLICATION_ID);
-  }
-
-  @Test
-  void delete_negative_entityExistInTe() {
+  void delete_negative_applicationIsInstalledForTenant() {
     var expectedEntityToDelete = TestValues.applicationDescriptorEntity();
     var tenants = List.of(TENANT_ID);
     when(repository.findById(APPLICATION_ID)).thenReturn(Optional.of(expectedEntityToDelete));
-
     when(entitlementService.getTenants(APPLICATION_ID, OKAPI_AUTH_TOKEN)).thenReturn(tenants);
 
     assertThatThrownBy(() -> service.delete(APPLICATION_ID, OKAPI_AUTH_TOKEN))
-      .isInstanceOf(EntityExistsException.class)
-      .hasMessage("Application Descriptor cannot be removed "
-        + "because it is installed for tenants: " + tenants);
+      .isInstanceOf(ApplicationInstalledException.class)
+      .hasMessage("Application Descriptor cannot be removed because it is installed for tenants: " + tenants);
+  }
+
+  @Test
+  void delete_negative_applicationIsNotFound() {
+    assertThatThrownBy(() -> service.delete(APPLICATION_ID, OKAPI_AUTH_TOKEN))
+      .isInstanceOf(EntityNotFoundException.class)
+      .hasMessage("Unable to find application descriptor with id " + APPLICATION_ID);
   }
 
   @Test

--- a/src/test/resources/sql/application-cleanup.sql
+++ b/src/test/resources/sql/application-cleanup.sql
@@ -1,0 +1,46 @@
+insert into application(id, name, version, application_descriptor)
+values
+  ('test-app-1.0.0', 'test-app', '1.0.0', '{
+    "id": "test-app-1.0.0",
+    "name": "test-app",
+    "version": "1.0.0",
+    "modules": [
+      { "id": "mod-foo-1.0.0", "name": "mod-foo", "version": "1.0.0" },
+      { "id": "mod-bar-1.0.0", "name": "mod-bar", "version": "1.0.0" }
+    ]
+  }'),
+  ('test-app-2.0.0', 'test-app', '2.0.0', '{
+    "id": "test-app-2.0.0",
+    "name": "test-app",
+    "version": "2.0.0",
+    "modules": [
+      { "id": "mod-foo-1.0.0", "name": "mod-foo", "version": "1.0.0" },
+      { "id": "mod-bar-1.0.1", "name": "mod-bar", "version": "1.0.1" }
+    ]
+  }');
+
+insert into module(id, name, version, discovery_url, descriptor, type)
+values
+  ('mod-foo-1.0.0', 'mod-foo', '1.0.0', 'http://mod-foo:8080', '{
+    "id": "mod-foo-1.0.0",
+    "name": "foo",
+    "provides": [ { "id": "int-foo", "version": "1.0" } ]
+  }', 'BACKEND'),
+  ('mod-bar-1.0.0', 'mod-bar', '1.0.0', 'http://mod-bar:8080', '{
+    "id": "mod-bar-1.0.0",
+    "name": "bar",
+    "provides": [ { "id": "int-bar", "version": "1.0" } ],
+    "requires": [ { "id": "int-foo", "version": "1.0" } ]
+  }', 'BACKEND'),
+  ('mod-bar-1.0.1', 'mod-bar', '1.0.1', 'http://mod-bar:8081', '{
+    "id": "mod-bar-1.0.1",
+    "name": "bar",
+    "provides": [ { "id": "int-bar", "version": "1.1" } ],
+    "requires": [ { "id": "int-foo", "version": "1.1" } ]
+  }', 'BACKEND');
+
+insert into application_module(application_id, module_id)
+values ('test-app-1.0.0', 'mod-foo-1.0.0'),
+       ('test-app-1.0.0', 'mod-bar-1.0.0'),
+       ('test-app-2.0.0', 'mod-foo-1.0.0'),
+       ('test-app-2.0.0', 'mod-bar-1.0.1');

--- a/src/test/resources/wiremock/stubs/mte/get-entitlement-application-cleanup-not-installed.json
+++ b/src/test/resources/wiremock/stubs/mte/get-entitlement-application-cleanup-not-installed.json
@@ -1,0 +1,22 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "/entitlements?query=applicationId%3Dtest-app-1.0.0",
+    "headers": {
+      "X-Okapi-Token": {
+        "matches": ".*"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json",
+      "Location": "/entitlements?query=applicationId%3Dtest-app-1.0.0"
+    },
+    "jsonBody": {
+      "totalRecords": 0,
+      "entitlements": []
+    }
+  }
+}

--- a/src/test/resources/wiremock/stubs/mte/get-entitlement-application-cleanup.json
+++ b/src/test/resources/wiremock/stubs/mte/get-entitlement-application-cleanup.json
@@ -1,0 +1,27 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "/entitlements?query=applicationId%3Dtest-app-2.0.0",
+    "headers": {
+      "X-Okapi-Token": {
+        "matches": ".*"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json",
+      "Location": "/entitlements?query=applicationId%3Dtest-app-2.0.0"
+    },
+    "jsonBody": {
+      "totalRecords": 1,
+      "entitlements": [
+        {
+          "applicationId": "test-app-2.0.0",
+          "tenantId": "abcec782-6bb6-48ae-888e-9020bef72485"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
### **Purpose**
Adds a `POST /applications/cleanup` endpoint that iterates over all registered application descriptors and attempts to delete any that are not currently installed (i.e., not entitled to any tenant). This provides a maintenance operation to remove stale application registrations. See https://folio-org.atlassian.net/browse/MGRAPPS-100.

### **Approach**
- Added `POST /applications/cleanup` to the OpenAPI spec (`am.yaml`) with a new `applicationCleanupResult` response schema that reports inspected, cleaned, skipped, and failed counts along with the respective IDs.
- Introduced `ApplicationInstalledException` to signal when a delete is blocked because the application has active entitlements.
- Implemented `ApplicationCleanupService` which loads all application IDs, attempts deletion via the existing `ApplicationService.delete()`, skips installed apps (catches `ApplicationInstalledException`), and captures any other failures without aborting the whole run.
- Added `findAllApplicationIds()` query to `ApplicationRepository`.
- The cleanup operation is gated: if `EntitlementService` is not available (FAR mode), a 501 is returned.
- Updated `ApplicationController` to wire the new service and expose the endpoint.
- Added unit tests (`ApplicationCleanupServiceTest`) and integration tests (`ApplicationCleanupIT`), plus FAR-mode and Kong registration IT coverage.

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.