### PR TITLE
APPPOCTOOL-85: update KafkaUtils import paths and configuration for producer

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@
 * Add API endpoint: Get Application Discovery By Query (MGRAPPS-98)
 * Migrate CI from Jenkins to GitHub Actions Maven central workflow (MGRAPPS-96)
 * Upgrade module to SpringBoot4.0 and Spring7.0 (MGRAPPS-102)
+* Migrate Kafka producer integration to `folio-kafka-producer` and move topic config to `application.kafka.producer` following applications-poc-tools Kafka module split (APPPOCTOOL-85)
 ---
 
 ## Version `v3.0.0` (12.03.2025)

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <openapi-tools.jackson-databind-nullable.version>0.2.10</openapi-tools.jackson-databind-nullable.version>
     <cql2pgjson.version>36.0.0</cql2pgjson.version>
     <folio-spring-cql.version>10.0.0</folio-spring-cql.version>
-    <applications-poc-tools.version>4.0.0-SNAPSHOT</applications-poc-tools.version>
+    <applications-poc-tools.version>4.1.0-SNAPSHOT</applications-poc-tools.version>
     <folio-java-checkstyle.version>1.2.0</folio-java-checkstyle.version>
     <semver4j.version>5.8.0</semver4j.version>
     <am.yaml-file>${project.basedir}/src/main/resources/swagger.api/am.yaml</am.yaml-file>
@@ -196,7 +196,7 @@
 
     <dependency>
       <groupId>org.folio</groupId>
-      <artifactId>folio-integration-kafka</artifactId>
+      <artifactId>folio-kafka-producer</artifactId>
       <version>${applications-poc-tools.version}</version>
     </dependency>
 

--- a/src/main/java/org/folio/am/integration/kafka/config/DiscoveryPublisherConfiguration.java
+++ b/src/main/java/org/folio/am/integration/kafka/config/DiscoveryPublisherConfiguration.java
@@ -8,14 +8,14 @@ import org.folio.am.integration.messaging.config.MessagingConfiguration;
 import org.folio.am.integration.messaging.outbox.config.TrxOutboxConfiguration;
 import org.folio.am.integration.messaging.outbox.config.TrxOutboxPublishingConfiguration;
 import org.folio.am.utils.ConditionalOnFarModeDisabled;
-import org.folio.integration.kafka.EnableKafka;
+import org.folio.integration.kafka.producer.EnableKafkaProducer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.messaging.core.GenericMessagingTemplate;
 
 @Configuration
-@EnableKafka
+@EnableKafkaProducer
 @Import({TrxOutboxPublishingConfiguration.class, TrxOutboxConfiguration.class, MessagingConfiguration.class})
 @ConditionalOnFarModeDisabled
 public class DiscoveryPublisherConfiguration {

--- a/src/main/java/org/folio/am/integration/messaging/channel/handler/KafkaHandler.java
+++ b/src/main/java/org/folio/am/integration/messaging/channel/handler/KafkaHandler.java
@@ -1,7 +1,7 @@
 package org.folio.am.integration.messaging.channel.handler;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
-import static org.folio.integration.kafka.KafkaUtils.getEnvTopicName;
+import static org.folio.integration.kafka.producer.KafkaUtils.getEnvTopicName;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;

--- a/src/main/java/org/folio/am/integration/messaging/outbox/publisher/TrxOutboxPollingPublisher.java
+++ b/src/main/java/org/folio/am/integration/messaging/outbox/publisher/TrxOutboxPollingPublisher.java
@@ -1,7 +1,7 @@
 package org.folio.am.integration.messaging.outbox.publisher;
 
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
-import static org.folio.integration.kafka.KafkaUtils.getEnvTopicName;
+import static org.folio.integration.kafka.producer.KafkaUtils.getEnvTopicName;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -74,10 +74,11 @@ application:
     mod-authtoken-url: ${MOD_AUTHTOKEN_URL}
   environment: ${ENV:folio}
   kafka:
-    topics:
-      - name: discovery
-        numPartitions: ${KAFKA_DISCOVERY_TOPIC_PARTITIONS:1}
-        replicationFactor: ${KAFKA_DISCOVERY_TOPIC_REPLICATION_FACTOR:}
+    producer:
+      topics:
+        - name: discovery
+          numPartitions: ${KAFKA_DISCOVERY_TOPIC_PARTITIONS:1}
+          replicationFactor: ${KAFKA_DISCOVERY_TOPIC_REPLICATION_FACTOR:}
   retry:
     tenant-routes:
       retry-delay: ${TENANT_ROUTES_RETRY_DELAY:500ms}

--- a/src/test/java/org/folio/am/integration/messaging/channel/handler/KafkaHandlerTest.java
+++ b/src/test/java/org/folio/am/integration/messaging/channel/handler/KafkaHandlerTest.java
@@ -5,7 +5,7 @@ import static org.folio.am.integration.messaging.MessagingTestValues.DESTINATION
 import static org.folio.am.integration.messaging.MessagingTestValues.PAYLOAD;
 import static org.folio.am.integration.messaging.MessagingTestValues.genericMessage;
 import static org.folio.am.integration.messaging.MessagingTestValues.genericMessageWithDestination;
-import static org.folio.integration.kafka.KafkaUtils.getEnvTopicName;
+import static org.folio.integration.kafka.producer.KafkaUtils.getEnvTopicName;
 import static org.mockito.Mockito.when;
 
 import org.folio.am.integration.messaging.MessagingTestValues.Payload;

--- a/src/test/java/org/folio/am/it/ApplicationCleanupIT.java
+++ b/src/test/java/org/folio/am/it/ApplicationCleanupIT.java
@@ -3,7 +3,7 @@ package org.folio.am.it;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.folio.am.integration.kafka.DiscoveryPublisher.DISCOVERY_DESTINATION;
 import static org.folio.am.support.TestUtils.generateAccessToken;
-import static org.folio.integration.kafka.KafkaUtils.getEnvTopicName;
+import static org.folio.integration.kafka.producer.KafkaUtils.getEnvTopicName;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;

--- a/src/test/java/org/folio/am/it/ApplicationDiscoveryIT.java
+++ b/src/test/java/org/folio/am/it/ApplicationDiscoveryIT.java
@@ -19,7 +19,7 @@ import static org.folio.am.support.TestConstants.UI_MODULE_ID;
 import static org.folio.am.support.TestValues.moduleDiscoveries;
 import static org.folio.am.support.TestValues.moduleFooDiscovery;
 import static org.folio.am.support.TestValues.uiModuleDiscovery;
-import static org.folio.integration.kafka.KafkaUtils.getEnvTopicName;
+import static org.folio.integration.kafka.producer.KafkaUtils.getEnvTopicName;
 import static org.folio.test.TestUtils.asJsonString;
 import static org.hamcrest.Matchers.is;
 import static org.springframework.http.MediaType.APPLICATION_JSON;

--- a/src/test/java/org/folio/am/it/ApplicationDiscoveryKongIT.java
+++ b/src/test/java/org/folio/am/it/ApplicationDiscoveryKongIT.java
@@ -22,7 +22,7 @@ import static org.folio.am.support.TestValues.moduleDiscoveries;
 import static org.folio.am.support.TestValues.moduleDiscovery;
 import static org.folio.am.support.TestValues.moduleFooDiscovery;
 import static org.folio.am.support.TestValues.uiModuleDiscovery;
-import static org.folio.integration.kafka.KafkaUtils.getEnvTopicName;
+import static org.folio.integration.kafka.producer.KafkaUtils.getEnvTopicName;
 import static org.folio.test.TestUtils.asJsonString;
 import static org.hamcrest.Matchers.is;
 import static org.springframework.http.MediaType.APPLICATION_JSON;

--- a/src/test/java/org/folio/am/it/ApplicationDiscoveryNoIntegrationsIT.java
+++ b/src/test/java/org/folio/am/it/ApplicationDiscoveryNoIntegrationsIT.java
@@ -16,7 +16,7 @@ import static org.folio.am.support.TestValues.moduleDiscoveries;
 import static org.folio.am.support.TestValues.moduleDiscovery;
 import static org.folio.am.support.TestValues.moduleFooDiscovery;
 import static org.folio.am.support.TestValues.uiModuleDiscovery;
-import static org.folio.integration.kafka.KafkaUtils.getEnvTopicName;
+import static org.folio.integration.kafka.producer.KafkaUtils.getEnvTopicName;
 import static org.folio.test.TestUtils.asJsonString;
 import static org.hamcrest.Matchers.is;
 import static org.springframework.http.MediaType.APPLICATION_JSON;

--- a/src/test/java/org/folio/am/it/ApplicationDiscoveryOkapiIT.java
+++ b/src/test/java/org/folio/am/it/ApplicationDiscoveryOkapiIT.java
@@ -14,7 +14,7 @@ import static org.folio.am.support.TestValues.moduleDiscoveries;
 import static org.folio.am.support.TestValues.moduleDiscovery;
 import static org.folio.am.support.TestValues.moduleFooDiscovery;
 import static org.folio.am.support.TestValues.uiModuleDiscovery;
-import static org.folio.integration.kafka.KafkaUtils.getEnvTopicName;
+import static org.folio.integration.kafka.producer.KafkaUtils.getEnvTopicName;
 import static org.folio.test.TestUtils.asJsonString;
 import static org.hamcrest.Matchers.is;
 import static org.springframework.http.MediaType.APPLICATION_JSON;

--- a/src/test/java/org/folio/am/it/ApplicationRemovingIT.java
+++ b/src/test/java/org/folio/am/it/ApplicationRemovingIT.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.folio.am.integration.kafka.DiscoveryPublisher.DISCOVERY_DESTINATION;
 import static org.folio.am.support.TestConstants.APPLICATION_ID;
 import static org.folio.am.support.TestUtils.generateAccessToken;
-import static org.folio.integration.kafka.KafkaUtils.getEnvTopicName;
+import static org.folio.integration.kafka.producer.KafkaUtils.getEnvTopicName;
 import static org.hamcrest.Matchers.is;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_METHOD;

--- a/src/test/java/org/folio/am/support/KafkaEventAssertions.java
+++ b/src/test/java/org/folio/am/support/KafkaEventAssertions.java
@@ -3,7 +3,7 @@ package org.folio.am.support;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.folio.am.integration.kafka.DiscoveryPublisher.DISCOVERY_DESTINATION;
 import static org.folio.common.utils.CollectionUtils.mapItems;
-import static org.folio.integration.kafka.KafkaUtils.getEnvTopicName;
+import static org.folio.integration.kafka.producer.KafkaUtils.getEnvTopicName;
 import static org.folio.test.FakeKafkaConsumer.getEvents;
 import static org.testcontainers.shaded.org.awaitility.Durations.ONE_MINUTE;
 import static org.testcontainers.shaded.org.awaitility.Durations.ONE_SECOND;


### PR DESCRIPTION
### **Purpose**
Align `mgr-applications` with the applications-poc-tools Kafka module split so discovery event publishing keeps working with the new producer library structure. Related upstream changes: https://github.com/folio-org/applications-poc-tools/pull/317 and https://github.com/folio-org/applications-poc-tools/pull/318.

### **Approach**
- bump `applications-poc-tools.version` to `4.1.0-SNAPSHOT`
- replace `folio-integration-kafka` with `folio-kafka-producer`
- switch discovery publishing config from `@EnableKafka` to `@EnableKafkaProducer`
- update `KafkaUtils` imports to the new producer package in production and test code
- move discovery topic configuration to `application.kafka.producer.topics`

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — No API, DB, or interface version changes in this repo; the change is limited to Kafka producer library wiring/config migration.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
