### PR TITLE
MGRAPPS-110: Upgrade dependencies for Kafka 4.2 compatibility in mgr-applications

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## Version `v4.1.0` (IN PROGRESS)
 * Allow interface to be both provided and require / optional in the same module descriptor (MGRAPPS-99)
+* Upgrade dependencies for Kafka 4.2 compatibility in mgr-applications (MGRAPPS-110)
 
 ---
 

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,9 @@
     <semver4j.version>5.8.0</semver4j.version>
     <am.yaml-file>${project.basedir}/src/main/resources/swagger.api/am.yaml</am.yaml-file>
 
+    <!-- overrides Spring Boot BOM default; can be removed once Spring Boot ships this version -->
+    <kafka.version>4.2.0</kafka.version>
+
     <!-- Test dependencies versions -->
     <mockito.version>5.23.0</mockito.version>
     <testcontainer.version>2.0.5</testcontainer.version>


### PR DESCRIPTION
### **Purpose**
Fix [MGRAPPS-110](https://folio-org.atlassian.net/browse/MGRAPPS-110)

### **Approach**
Updated pom with following - `<kafka.version>4.2.0</kafka.version>`
After the update, maven effective pom show the correct kafka version
<img width="1136" height="738" alt="image" src="https://github.com/user-attachments/assets/fed43801-76f5-4c4f-8817-fb5656d75dc8" />


---

### **Pre-Review Checklist**

- [ ] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
