### PR TITLE
EUREKASUP-156: Multi-version module deployment – application-scoped bootstrap

### DIFF
--- a/src/main/java/org/folio/am/controller/ModuleBootstrapController.java
+++ b/src/main/java/org/folio/am/controller/ModuleBootstrapController.java
@@ -14,9 +14,7 @@ public class ModuleBootstrapController extends BaseController implements ModuleB
   private final ModuleBootstrapService service;
 
   @Override
-  public ResponseEntity<ModuleBootstrap> getModuleBootstrap(String id) {
-    var moduleBootstrap = service.getById(id);
-
-    return ResponseEntity.ok(moduleBootstrap);
+  public ResponseEntity<ModuleBootstrap> getModuleBootstrap(String id, String applicationId) {
+    return ResponseEntity.ok(service.getById(id, applicationId));
   }
 }

--- a/src/main/java/org/folio/am/repository/ModuleBootstrapRepository.java
+++ b/src/main/java/org/folio/am/repository/ModuleBootstrapRepository.java
@@ -1,5 +1,6 @@
 package org.folio.am.repository;
 
+import java.util.Collection;
 import java.util.List;
 import org.folio.am.domain.entity.ModuleBootstrapView;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -21,4 +22,23 @@ public interface ModuleBootstrapRepository extends JpaRepository<ModuleBootstrap
     + "p.id IN (SELECT r.id FROM InterfaceReferenceEntity r WHERE r.moduleId = :moduleId AND "
     + "(r.type = 'REQUIRES' OR r.type = 'OPTIONAL')))) and (view.location is not null OR view.id = :moduleId)")
   List<ModuleBootstrapView> findAllRequiredByModuleId(@Param("moduleId") String moduleId);
+
+  /**
+   * Queries the module and all its dependencies by the given id, filtered to specified applications.
+   *
+   * @param moduleId the module identifier
+   * @param applicationIds the application identifiers to filter by
+   * @return List of module views belonging to specified applications
+   */
+  @Query(value = "SELECT DISTINCT view FROM ModuleBootstrapView view WHERE "
+    + "(view.id = :moduleId OR view.id IN ("
+    + "  SELECT p.moduleId FROM InterfaceReferenceEntity p WHERE p.type = 'PROVIDES' AND "
+    + "  p.id IN (SELECT r.id FROM InterfaceReferenceEntity r WHERE r.moduleId = :moduleId AND "
+    + "  (r.type = 'REQUIRES' OR r.type = 'OPTIONAL'))"
+    + ")) "
+    + "AND (view.location IS NOT NULL OR view.id = :moduleId) "
+    + "AND view.applicationId IN :applicationIds")
+  List<ModuleBootstrapView> findAllRequiredByModuleIdAndApplicationIds(
+    @Param("moduleId") String moduleId,
+    @Param("applicationIds") Collection<String> applicationIds);
 }

--- a/src/main/java/org/folio/am/service/ApplicationClosureResolver.java
+++ b/src/main/java/org/folio/am/service/ApplicationClosureResolver.java
@@ -26,29 +26,28 @@ public class ApplicationClosureResolver {
   public Set<String> resolve(Set<String> applicationIds) {
     var visited = new HashSet<String>();
     var queue = new ArrayDeque<String>(applicationIds);
-
     while (!queue.isEmpty()) {
-      var batch = new HashSet<String>();
-      while (!queue.isEmpty()) {
-        var id = queue.poll();
-        if (visited.add(id)) {
-          batch.add(id);
-        }
-      }
+      var batch = drainUnvisited(queue, visited);
       if (batch.isEmpty()) {
         continue;
       }
-
-      var entities = applicationRepository.findAllById(batch);
-      for (var entity : entities) {
-        for (var depId : extractDependencyIds(entity)) {
-          if (!visited.contains(depId)) {
-            queue.add(depId);
-          }
-        }
-      }
+      applicationRepository.findAllById(batch).stream()
+        .flatMap(entity -> extractDependencyIds(entity).stream())
+        .filter(depId -> !visited.contains(depId))
+        .forEach(queue::add);
     }
     return visited;
+  }
+
+  private Set<String> drainUnvisited(ArrayDeque<String> queue, Set<String> visited) {
+    var batch = new HashSet<String>();
+    while (!queue.isEmpty()) {
+      var id = queue.poll();
+      if (visited.add(id)) {
+        batch.add(id);
+      }
+    }
+    return batch;
   }
 
   private Set<String> extractDependencyIds(ApplicationEntity entity) {

--- a/src/main/java/org/folio/am/service/ApplicationClosureResolver.java
+++ b/src/main/java/org/folio/am/service/ApplicationClosureResolver.java
@@ -1,0 +1,71 @@
+package org.folio.am.service;
+
+import java.util.ArrayDeque;
+import java.util.HashSet;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.apache.commons.collections4.CollectionUtils;
+import org.folio.am.domain.entity.ApplicationEntity;
+import org.folio.am.repository.ApplicationRepository;
+import org.springframework.stereotype.Service;
+
+@Log4j2
+@Service
+@RequiredArgsConstructor
+public class ApplicationClosureResolver {
+
+  private final ApplicationRepository applicationRepository;
+
+  /**
+   * Computes the transitive closure of application dependencies starting from the given IDs.
+   *
+   * @param applicationIds root application IDs
+   * @return set of all application IDs reachable via the dependency graph (including roots)
+   */
+  public Set<String> resolve(Set<String> applicationIds) {
+    var visited = new HashSet<String>();
+    var queue = new ArrayDeque<String>(applicationIds);
+
+    while (!queue.isEmpty()) {
+      var batch = new HashSet<String>();
+      while (!queue.isEmpty()) {
+        var id = queue.poll();
+        if (visited.add(id)) {
+          batch.add(id);
+        }
+      }
+      if (batch.isEmpty()) {
+        continue;
+      }
+
+      var entities = applicationRepository.findAllById(batch);
+      for (var entity : entities) {
+        for (var depId : extractDependencyIds(entity)) {
+          if (!visited.contains(depId)) {
+            queue.add(depId);
+          }
+        }
+      }
+    }
+    return visited;
+  }
+
+  private Set<String> extractDependencyIds(ApplicationEntity entity) {
+    var descriptor = entity.getApplicationDescriptor();
+    if (descriptor == null) {
+      return Set.of();
+    }
+    var deps = descriptor.getDependencies();
+    if (CollectionUtils.isEmpty(deps)) {
+      return Set.of();
+    }
+    var result = new HashSet<String>();
+    for (var dep : deps) {
+      if (dep.getName() != null && dep.getVersion() != null) {
+        result.add(dep.getName() + "-" + dep.getVersion());
+      }
+    }
+    return result;
+  }
+}

--- a/src/main/java/org/folio/am/service/ApplicationClosureResolver.java
+++ b/src/main/java/org/folio/am/service/ApplicationClosureResolver.java
@@ -25,7 +25,7 @@ public class ApplicationClosureResolver {
    */
   public Set<String> resolve(Set<String> applicationIds) {
     var visited = new HashSet<String>();
-    var queue = new ArrayDeque<String>(applicationIds);
+    var queue = new ArrayDeque<>(applicationIds);
     while (!queue.isEmpty()) {
       var batch = drainUnvisited(queue, visited);
       if (batch.isEmpty()) {
@@ -53,10 +53,12 @@ public class ApplicationClosureResolver {
   private Set<String> extractDependencyIds(ApplicationEntity entity) {
     var descriptor = entity.getApplicationDescriptor();
     if (descriptor == null) {
+      log.debug("Application {} has null descriptor or no dependencies; closure narrows here", entity.getId());
       return Set.of();
     }
     var deps = descriptor.getDependencies();
     if (CollectionUtils.isEmpty(deps)) {
+      log.debug("Application {} has null descriptor or no dependencies; closure narrows here", entity.getId());
       return Set.of();
     }
     var result = new HashSet<String>();

--- a/src/main/java/org/folio/am/service/ApplicationClosureResolver.java
+++ b/src/main/java/org/folio/am/service/ApplicationClosureResolver.java
@@ -61,9 +61,7 @@ public class ApplicationClosureResolver {
     }
     var result = new HashSet<String>();
     for (var dep : deps) {
-      if (dep.getName() != null && dep.getVersion() != null) {
-        result.add(dep.getName() + "-" + dep.getVersion());
-      }
+      result.add(dep.getName() + "-" + dep.getVersion());
     }
     return result;
   }

--- a/src/main/java/org/folio/am/service/ModuleBootstrapService.java
+++ b/src/main/java/org/folio/am/service/ModuleBootstrapService.java
@@ -10,7 +10,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.folio.am.domain.dto.ModuleBootstrap;
@@ -43,7 +42,7 @@ public class ModuleBootstrapService {
    */
   @Transactional(readOnly = true)
   public ModuleBootstrap getById(String moduleId) {
-    return getById(moduleId, null);
+    return doGetById(moduleId, null);
   }
 
   /**
@@ -57,6 +56,10 @@ public class ModuleBootstrapService {
    */
   @Transactional(readOnly = true)
   public ModuleBootstrap getById(String moduleId, String applicationId) {
+    return doGetById(moduleId, applicationId);
+  }
+
+  private ModuleBootstrap doGetById(String moduleId, String applicationId) {
     var views = applicationId == null
       ? repository.findAllRequiredByModuleId(moduleId)
       : repository.findAllRequiredByModuleIdAndApplicationIds(
@@ -117,7 +120,7 @@ public class ModuleBootstrapService {
     var descriptor = moduleView.getDescriptor();
     return Stream.concat(toStream(descriptor.getRequires()), toStream(descriptor.getOptional()))
       .map(InterfaceReference::getId)
-      .collect(Collectors.toList());
+      .toList();
   }
 
   private List<ModuleBootstrapDiscovery> toModuleDiscoveries(List<String> requiredInterfaces,
@@ -128,7 +131,7 @@ public class ModuleBootstrapService {
 
     removeNotRequiredInterfaces(requiredInterfaces, moduleViews);
 
-    return moduleViews.stream().map(mapper::convert).collect(Collectors.toList());
+    return moduleViews.stream().map(mapper::convert).toList();
   }
 
   private static void removeNotRequiredInterfaces(List<String> requiredInterfaces, List<ModuleBootstrapView> views) {

--- a/src/main/java/org/folio/am/service/ModuleBootstrapService.java
+++ b/src/main/java/org/folio/am/service/ModuleBootstrapService.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -30,6 +31,7 @@ public class ModuleBootstrapService {
 
   private final ModuleBootstrapRepository repository;
   private final ModuleBootstrapMapper mapper;
+  private final ApplicationClosureResolver applicationClosureResolver;
 
   /**
    * Retrieves a module bootstrap data including information for the modules that provides interfaces listed in
@@ -41,7 +43,24 @@ public class ModuleBootstrapService {
    */
   @Transactional(readOnly = true)
   public ModuleBootstrap getById(String moduleId) {
-    var views = repository.findAllRequiredByModuleId(moduleId);
+    return getById(moduleId, null);
+  }
+
+  /**
+   * Retrieves a module bootstrap data scoped to an application closure when {@code applicationId} is provided,
+   * or falls back to the legacy all-applications query when it is {@code null}.
+   *
+   * @param moduleId      - the module identifier
+   * @param applicationId - optional application identifier; when non-null, providers are restricted to the
+   *                        transitive closure of the application's dependencies
+   * @return Module bootstrap data
+   */
+  @Transactional(readOnly = true)
+  public ModuleBootstrap getById(String moduleId, String applicationId) {
+    var views = applicationId == null
+      ? repository.findAllRequiredByModuleId(moduleId)
+      : repository.findAllRequiredByModuleIdAndApplicationIds(
+          moduleId, applicationClosureResolver.resolve(Set.of(applicationId)));
 
     var moduleView = removeModuleViewById(moduleId, views);
     var module = mapper.convert(moduleView);

--- a/src/main/java/org/folio/am/service/ModuleBootstrapService.java
+++ b/src/main/java/org/folio/am/service/ModuleBootstrapService.java
@@ -12,6 +12,8 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.apache.commons.lang3.StringUtils;
 import org.folio.am.domain.dto.ModuleBootstrap;
 import org.folio.am.domain.dto.ModuleBootstrapDiscovery;
 import org.folio.am.domain.entity.ModuleBootstrapView;
@@ -24,6 +26,7 @@ import org.folio.common.utils.InterfaceComparisonUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Log4j2
 @Service
 @RequiredArgsConstructor
 public class ModuleBootstrapService {
@@ -60,10 +63,8 @@ public class ModuleBootstrapService {
   }
 
   private ModuleBootstrap doGetById(String moduleId, String applicationId) {
-    var views = applicationId == null
-      ? repository.findAllRequiredByModuleId(moduleId)
-      : repository.findAllRequiredByModuleIdAndApplicationIds(
-          moduleId, applicationClosureResolver.resolve(Set.of(applicationId)));
+    var loadResult = loadModuleViews(moduleId, applicationId);
+    var views = loadResult.views();
 
     var moduleView = removeModuleViewById(moduleId, views);
     var module = mapper.convert(moduleView);
@@ -71,12 +72,30 @@ public class ModuleBootstrapService {
     var requiredInterfaces = getRequiredOptionalInterfaces(moduleView);
     var requiredModules = toModuleDiscoveries(requiredInterfaces, views);
 
-    var preferred = applicationId == null ? Set.<String>of() : Set.of(applicationId);
+    var preferred = loadResult.preferredApplicationId() == null
+      ? Set.<String>of()
+      : Set.of(loadResult.preferredApplicationId());
     requiredModules = deduplicateRequiredModules(requiredModules, preferred);
 
     return new ModuleBootstrap()
       .module(module)
       .requiredModules(requiredModules);
+  }
+
+  private LoadResult loadModuleViews(String moduleId, String applicationId) {
+    var appId = StringUtils.isBlank(applicationId) ? null : applicationId;
+    if (appId == null) {
+      return new LoadResult(repository.findAllRequiredByModuleId(moduleId), null);
+    }
+
+    var closure = applicationClosureResolver.resolve(Set.of(appId));
+    if (closure.isEmpty()) {
+      log.warn("Empty application closure for applicationId={}, falling back to unscoped bootstrap", appId);
+      return new LoadResult(repository.findAllRequiredByModuleId(moduleId), null);
+    }
+
+    var views = repository.findAllRequiredByModuleIdAndApplicationIds(moduleId, closure);
+    return new LoadResult(views, appId);
   }
 
   private List<ModuleBootstrapDiscovery> deduplicateRequiredModules(
@@ -144,5 +163,8 @@ public class ModuleBootstrapService {
 
   private static Predicate<InterfaceDescriptor> notRequiredInterface(List<String> requiredInterfaces) {
     return i -> !requiredInterfaces.contains(i.getId());
+  }
+
+  private record LoadResult(List<ModuleBootstrapView> views, String preferredApplicationId) {
   }
 }

--- a/src/main/java/org/folio/am/service/ModuleBootstrapService.java
+++ b/src/main/java/org/folio/am/service/ModuleBootstrapService.java
@@ -68,34 +68,40 @@ public class ModuleBootstrapService {
     var requiredInterfaces = getRequiredOptionalInterfaces(moduleView);
     var requiredModules = toModuleDiscoveries(requiredInterfaces, views);
 
-    requiredModules = deduplicateRequiredModules(requiredModules);
+    var preferred = applicationId == null ? Set.<String>of() : Set.of(applicationId);
+    requiredModules = deduplicateRequiredModules(requiredModules, preferred);
 
     return new ModuleBootstrap()
       .module(module)
       .requiredModules(requiredModules);
   }
 
-  private List<ModuleBootstrapDiscovery> deduplicateRequiredModules(List<ModuleBootstrapDiscovery> requiredModules) {
+  private List<ModuleBootstrapDiscovery> deduplicateRequiredModules(
+      List<ModuleBootstrapDiscovery> requiredModules,
+      Set<String> preferredApplicationIds) {
     var results = new HashMap<String, ModuleBootstrapDiscovery>();
 
-    for (var moduleBootstrapDiscovery : requiredModules) {
-      var moduleNameAndVersion = getNameAndVersion(moduleBootstrapDiscovery.getModuleId());
-      var moduleName = moduleNameAndVersion.getLeft();
-      var moduleVersion = moduleNameAndVersion.getRight();
-
-      var existingValue = results.get(moduleName);
-      if (existingValue == null) {
-        results.put(moduleName, moduleBootstrapDiscovery);
-      } else {
-        var existingValueVersion = getNameAndVersion(existingValue.getModuleId()).getRight();
-        if (InterfaceComparisonUtils.compare("", moduleVersion,
-          "", existingValueVersion) > 0) {
-          results.put(moduleName, moduleBootstrapDiscovery);
-        }
+    for (var candidate : requiredModules) {
+      var moduleName = getNameAndVersion(candidate.getModuleId()).getLeft();
+      var existing = results.get(moduleName);
+      if (existing == null || isBetterCandidate(candidate, existing, preferredApplicationIds)) {
+        results.put(moduleName, candidate);
       }
     }
 
     return results.values().stream().toList();
+  }
+
+  private boolean isBetterCandidate(ModuleBootstrapDiscovery candidate, ModuleBootstrapDiscovery existing,
+      Set<String> preferredApplicationIds) {
+    var candidatePreferred = preferredApplicationIds.contains(candidate.getApplicationId());
+    var existingPreferred = preferredApplicationIds.contains(existing.getApplicationId());
+    if (candidatePreferred != existingPreferred) {
+      return candidatePreferred;
+    }
+    var candidateVersion = getNameAndVersion(candidate.getModuleId()).getRight();
+    var existingVersion = getNameAndVersion(existing.getModuleId()).getRight();
+    return InterfaceComparisonUtils.compare("", candidateVersion, "", existingVersion) > 0;
   }
 
   private ModuleBootstrapView removeModuleViewById(String moduleId, List<ModuleBootstrapView> result) {

--- a/src/main/resources/swagger.api/am.yaml
+++ b/src/main/resources/swagger.api/am.yaml
@@ -238,6 +238,12 @@ paths:
         - module-bootstrap
       parameters:
         - $ref: '#/components/parameters/path-entity-id'
+        - name: applicationId
+          in: query
+          required: false
+          description: "Scope module bootstrap resolution to the transitive closure of this application."
+          schema:
+            type: string
       responses:
         '200':
           description: A module bootstrap info

--- a/src/test/java/org/folio/am/controller/ModuleBootstrapControllerTest.java
+++ b/src/test/java/org/folio/am/controller/ModuleBootstrapControllerTest.java
@@ -47,7 +47,7 @@ class ModuleBootstrapControllerTest {
     var requiredModules = moduleBootstrapDiscovery(MODULE_BAR_ID, MODULE_BAR_INTERFACE_ID);
     var expectedModuleBootstrap = moduleBootstrap(module, requiredModules);
 
-    when(service.getById(MODULE_FOO_ID)).thenReturn(expectedModuleBootstrap);
+    when(service.getById(MODULE_FOO_ID, null)).thenReturn(expectedModuleBootstrap);
 
     var mvcResult = mockMvc.perform(get(ENDPOINT_PATH, MODULE_FOO_ID)
         .contentType(APPLICATION_JSON))
@@ -61,7 +61,7 @@ class ModuleBootstrapControllerTest {
   @Test
   void get_negative() throws Exception {
     var errorMessage = "Module not found by id: " + MODULE_FOO_ID;
-    when(service.getById(MODULE_FOO_ID)).thenThrow(new EntityNotFoundException(errorMessage));
+    when(service.getById(MODULE_FOO_ID, null)).thenThrow(new EntityNotFoundException(errorMessage));
     mockMvc.perform(get(ENDPOINT_PATH, MODULE_FOO_ID)
         .contentType(APPLICATION_JSON))
       .andExpect(status().isNotFound())

--- a/src/test/java/org/folio/am/it/ModuleBootstrapIT.java
+++ b/src/test/java/org/folio/am/it/ModuleBootstrapIT.java
@@ -6,12 +6,16 @@ import static org.folio.am.support.TestValues.module;
 import static org.folio.am.support.TestValues.moduleDiscovery;
 import static org.folio.test.TestUtils.asJsonString;
 import static org.folio.test.TestUtils.readString;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasItem;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_METHOD;
 import static org.springframework.test.json.JsonCompareMode.STRICT;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.List;
@@ -34,6 +38,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.SqlMergeMode;
+import org.springframework.test.context.jdbc.SqlMergeMode.MergeMode;
 
 @IntegrationTest
 @EnableKeycloakSecurity
@@ -139,6 +145,35 @@ class ModuleBootstrapIT extends BaseIntegrationTest {
         .header(TOKEN, generateAccessToken(keycloakProperties)))
       .andExpect(status().isOk())
       .andExpect(content().json(asJsonString(expectedBootstrapResponse), STRICT));
+  }
+
+  @Test
+  @SqlMergeMode(MergeMode.OVERRIDE)
+  @Sql(scripts = "classpath:/sql/module-bootstrap/cross-app-collision.sql",
+    executionPhase = BEFORE_TEST_METHOD)
+  @Sql(scripts = "classpath:/sql/truncate-tables.sql",
+    executionPhase = AFTER_TEST_METHOD)
+  void getModuleBootstrap_withApplicationId_returnsApplicationScopedRequiredModule() throws Exception {
+    mockMvc.perform(get("/modules/{id}", "mod-users-keycloak-3.0.13")
+        .param("applicationId", "app-platform-minimal-2.0.53")
+        .header(TOKEN, generateAccessToken(keycloakProperties)))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.requiredModules[*].moduleId",
+        containsInAnyOrder("mod-users-19.5.4")));
+  }
+
+  @Test
+  @SqlMergeMode(MergeMode.OVERRIDE)
+  @Sql(scripts = "classpath:/sql/module-bootstrap/cross-app-collision.sql",
+    executionPhase = BEFORE_TEST_METHOD)
+  @Sql(scripts = "classpath:/sql/truncate-tables.sql",
+    executionPhase = AFTER_TEST_METHOD)
+  void getModuleBootstrap_withoutApplicationId_includesHighestVersionModule() throws Exception {
+    mockMvc.perform(get("/modules/{id}", "mod-users-keycloak-3.0.13")
+        .header(TOKEN, generateAccessToken(keycloakProperties)))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.requiredModules[*].moduleId",
+        hasItem("mod-users-19.6.0")));
   }
 
   private void postApplication(ApplicationDescriptor applicationDescriptor) throws Exception {

--- a/src/test/java/org/folio/am/repository/ModuleBootstrapRepositoryIT.java
+++ b/src/test/java/org/folio/am/repository/ModuleBootstrapRepositoryIT.java
@@ -79,9 +79,9 @@ class ModuleBootstrapRepositoryIT extends BaseRepositoryTest {
       "mod-users-keycloak-3.0.13", List.of("app-platform-minimal-2.0.53"));
 
     var ids = result.stream().map(ModuleBootstrapView::getId).toList();
-    assertThat(ids).containsExactlyInAnyOrder(
-      "mod-users-keycloak-3.0.13", "mod-users-19.5.4");
-    assertThat(ids).doesNotContain("mod-users-19.6.0");
+    assertThat(ids)
+      .containsExactlyInAnyOrder("mod-users-keycloak-3.0.13", "mod-users-19.5.4")
+      .doesNotContain("mod-users-19.6.0");
   }
 
   private Predicate<ModuleBootstrapView> matchView(String moduleId, String appId, String location) {

--- a/src/test/java/org/folio/am/repository/ModuleBootstrapRepositoryIT.java
+++ b/src/test/java/org/folio/am/repository/ModuleBootstrapRepositoryIT.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_METHOD;
 
+import java.util.List;
 import java.util.function.Predicate;
 import org.folio.am.domain.entity.ModuleBootstrapView;
 import org.folio.am.support.base.BaseRepositoryTest;
@@ -11,6 +12,8 @@ import org.folio.test.types.IntegrationTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.SqlMergeMode;
+import org.springframework.test.context.jdbc.SqlMergeMode.MergeMode;
 
 @IntegrationTest
 @Sql(scripts =
@@ -65,6 +68,20 @@ class ModuleBootstrapRepositoryIT extends BaseRepositoryTest {
     assertThat(result)
       .hasSize(1)
       .anyMatch(matchView(MODULE_BAR_ID, APP_2_0_0_ID, MODULE_BAR_DISCOVERY_URL));
+  }
+
+  @Test
+  @SqlMergeMode(MergeMode.OVERRIDE)
+  @Sql(scripts = "classpath:/sql/module-bootstrap/cross-app-collision.sql", executionPhase = BEFORE_TEST_METHOD)
+  @Sql(scripts = "classpath:/sql/truncate-tables.sql", executionPhase = AFTER_TEST_METHOD)
+  void findAllRequiredByModuleIdAndApplicationIds_filtersByApplication() {
+    var result = repository.findAllRequiredByModuleIdAndApplicationIds(
+      "mod-users-keycloak-3.0.13", List.of("app-platform-minimal-2.0.53"));
+
+    var ids = result.stream().map(ModuleBootstrapView::getId).toList();
+    assertThat(ids).containsExactlyInAnyOrder(
+      "mod-users-keycloak-3.0.13", "mod-users-19.5.4");
+    assertThat(ids).doesNotContain("mod-users-19.6.0");
   }
 
   private Predicate<ModuleBootstrapView> matchView(String moduleId, String appId, String location) {

--- a/src/test/java/org/folio/am/service/ApplicationClosureResolverTest.java
+++ b/src/test/java/org/folio/am/service/ApplicationClosureResolverTest.java
@@ -1,0 +1,78 @@
+package org.folio.am.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Set;
+import org.folio.am.domain.dto.ApplicationDescriptor;
+import org.folio.am.domain.dto.Dependency;
+import org.folio.am.domain.entity.ApplicationEntity;
+import org.folio.am.repository.ApplicationRepository;
+import org.folio.test.types.UnitTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@UnitTest
+@ExtendWith(MockitoExtension.class)
+class ApplicationClosureResolverTest {
+
+  @Mock
+  ApplicationRepository applicationRepository;
+
+  @InjectMocks
+  ApplicationClosureResolver resolver;
+
+  @Test
+  void resolve_returnsTransitiveClosureOfDependencies() {
+    var rootDescriptor = descriptor(new Dependency("app-platform-complete", "1.2.0"));
+    var depDescriptor = descriptor(new Dependency("app-platform-base", "0.5.0"));
+    var baseDescriptor = new ApplicationDescriptor();
+
+    when(applicationRepository.findAllById(Set.of("app-platform-minimal-2.0.53")))
+      .thenReturn(List.of(entity("app-platform-minimal-2.0.53", rootDescriptor)));
+    when(applicationRepository.findAllById(Set.of("app-platform-complete-1.2.0")))
+      .thenReturn(List.of(entity("app-platform-complete-1.2.0", depDescriptor)));
+    when(applicationRepository.findAllById(Set.of("app-platform-base-0.5.0")))
+      .thenReturn(List.of(entity("app-platform-base-0.5.0", baseDescriptor)));
+
+    var closure = resolver.resolve(Set.of("app-platform-minimal-2.0.53"));
+
+    assertThat(closure).containsExactlyInAnyOrder(
+      "app-platform-minimal-2.0.53",
+      "app-platform-complete-1.2.0",
+      "app-platform-base-0.5.0");
+  }
+
+  @Test
+  void resolve_handlesCyclesWithoutInfiniteLoop() {
+    // A-1 depends on B-1, B-1 depends on A-1 — mutual cycle
+    var aDesc = descriptor(new Dependency("B", "1"));
+    var bDesc = descriptor(new Dependency("A", "1"));
+
+    when(applicationRepository.findAllById(Set.of("A-1")))
+      .thenReturn(List.of(entity("A-1", aDesc)));
+    when(applicationRepository.findAllById(Set.of("B-1")))
+      .thenReturn(List.of(entity("B-1", bDesc)));
+
+    assertThat(resolver.resolve(Set.of("A-1"))).containsExactlyInAnyOrder("A-1", "B-1");
+  }
+
+  private static ApplicationDescriptor descriptor(Dependency... deps) {
+    var d = new ApplicationDescriptor();
+    for (var dep : deps) {
+      d.addDependenciesItem(dep);
+    }
+    return d;
+  }
+
+  private static ApplicationEntity entity(String id, ApplicationDescriptor descriptor) {
+    var e = new ApplicationEntity();
+    e.setId(id);
+    e.setApplicationDescriptor(descriptor);
+    return e;
+  }
+}

--- a/src/test/java/org/folio/am/service/ApplicationClosureResolverTest.java
+++ b/src/test/java/org/folio/am/service/ApplicationClosureResolverTest.java
@@ -50,13 +50,13 @@ class ApplicationClosureResolverTest {
   @Test
   void resolve_handlesCyclesWithoutInfiniteLoop() {
     // A-1 depends on B-1, B-1 depends on A-1 — mutual cycle
-    var aDesc = descriptor(new Dependency("B", "1"));
-    var bDesc = descriptor(new Dependency("A", "1"));
+    var descriptorA = descriptor(new Dependency("B", "1"));
+    var descriptorB = descriptor(new Dependency("A", "1"));
 
     when(applicationRepository.findAllById(Set.of("A-1")))
-      .thenReturn(List.of(entity("A-1", aDesc)));
+      .thenReturn(List.of(entity("A-1", descriptorA)));
     when(applicationRepository.findAllById(Set.of("B-1")))
-      .thenReturn(List.of(entity("B-1", bDesc)));
+      .thenReturn(List.of(entity("B-1", descriptorB)));
 
     assertThat(resolver.resolve(Set.of("A-1"))).containsExactlyInAnyOrder("A-1", "B-1");
   }

--- a/src/test/java/org/folio/am/service/ModuleBootstrapServiceTest.java
+++ b/src/test/java/org/folio/am/service/ModuleBootstrapServiceTest.java
@@ -12,12 +12,16 @@ import static org.folio.am.support.TestConstants.MODULE_FOO_INTERFACE_ID;
 import static org.folio.am.support.TestValues.moduleBootstrap;
 import static org.folio.am.support.TestValues.moduleBootstrapDiscovery;
 import static org.folio.am.support.TestValues.moduleBootstrapView;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import jakarta.persistence.EntityNotFoundException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import org.folio.am.mapper.ModuleBootstrapMapperImpl;
 import org.folio.am.repository.ModuleBootstrapRepository;
 import org.folio.common.domain.model.InterfaceReference;
@@ -33,12 +37,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class ModuleBootstrapServiceTest {
 
   @Mock private ModuleBootstrapRepository repository;
+  @Mock private ApplicationClosureResolver applicationClosureResolver;
 
   private ModuleBootstrapService service;
 
   @BeforeEach
   void setUp() {
-    service = new ModuleBootstrapService(repository, new ModuleBootstrapMapperImpl());
+    service = new ModuleBootstrapService(repository, new ModuleBootstrapMapperImpl(), applicationClosureResolver);
   }
 
   @Test
@@ -99,5 +104,43 @@ class ModuleBootstrapServiceTest {
 
     assertThatThrownBy(() -> service.getById(MODULE_FOO_ID)).isInstanceOf(EntityNotFoundException.class)
       .hasMessage("Module not found by id: " + MODULE_FOO_ID);
+  }
+
+  @Test
+  void getById_withApplicationId_resolvesClosureAndCallsScopedQuery() {
+    var applicationId = "app-platform-minimal-2.0.53";
+    var depAppId = "app-platform-base-0.5.0";
+    var closure = Set.of(applicationId, depAppId);
+
+    var moduleView = moduleBootstrapView(MODULE_FOO_ID, MODULE_FOO_INTERFACE_ID);
+    moduleView.getDescriptor().addRequiresItem(new InterfaceReference().id(MODULE_BAR_INTERFACE_ID));
+    var depView = moduleBootstrapView(MODULE_BAR_ID, MODULE_BAR_INTERFACE_ID);
+    var views = new ArrayList<>(asList(moduleView, depView));
+
+    when(applicationClosureResolver.resolve(Set.of(applicationId))).thenReturn(closure);
+    when(repository.findAllRequiredByModuleIdAndApplicationIds(MODULE_FOO_ID, closure)).thenReturn(views);
+
+    var result = service.getById(MODULE_FOO_ID, applicationId);
+
+    assertThat(result.getModule().getModuleId()).isEqualTo(MODULE_FOO_ID);
+    assertThat(result.getRequiredModules())
+      .extracting(org.folio.am.domain.dto.ModuleBootstrapDiscovery::getModuleId)
+      .containsExactly(MODULE_BAR_ID);
+
+    verify(applicationClosureResolver).resolve(Set.of(applicationId));
+    verify(repository).findAllRequiredByModuleIdAndApplicationIds(MODULE_FOO_ID, closure);
+    verifyNoMoreInteractions(repository);
+  }
+
+  @Test
+  void getById_withoutApplicationId_fallsBackToLegacyQuery() {
+    var moduleView = moduleBootstrapView(MODULE_FOO_ID, MODULE_FOO_INTERFACE_ID);
+    when(repository.findAllRequiredByModuleId(MODULE_FOO_ID)).thenReturn(new ArrayList<>(List.of(moduleView)));
+
+    var result = service.getById(MODULE_FOO_ID, null);
+
+    assertThat(result.getModule().getModuleId()).isEqualTo(MODULE_FOO_ID);
+    verify(repository).findAllRequiredByModuleId(MODULE_FOO_ID);
+    verifyNoInteractions(applicationClosureResolver);
   }
 }

--- a/src/test/java/org/folio/am/service/ModuleBootstrapServiceTest.java
+++ b/src/test/java/org/folio/am/service/ModuleBootstrapServiceTest.java
@@ -95,7 +95,7 @@ class ModuleBootstrapServiceTest {
 
     var actual = service.getById(MODULE_BAR_ID);
     assertThat(actual.getRequiredModules()).hasSize(1);
-    assertThat(actual.getRequiredModules().get(0).getModuleId()).isEqualTo(MODULE_FOO1_1_ID);
+    assertThat(actual.getRequiredModules().getFirst().getModuleId()).isEqualTo(MODULE_FOO1_1_ID);
   }
 
   @Test
@@ -142,6 +142,47 @@ class ModuleBootstrapServiceTest {
     assertThat(result.getModule().getModuleId()).isEqualTo(MODULE_FOO_ID);
     verify(repository).findAllRequiredByModuleId(MODULE_FOO_ID);
     verifyNoInteractions(applicationClosureResolver);
+  }
+
+  @Test
+  void getById_withEmptyApplicationId_fallsBackToLegacyQuery() {
+    var moduleView = moduleBootstrapView(MODULE_FOO_ID, MODULE_FOO_INTERFACE_ID);
+    when(repository.findAllRequiredByModuleId(MODULE_FOO_ID)).thenReturn(new ArrayList<>(List.of(moduleView)));
+
+    var result = service.getById(MODULE_FOO_ID, "");
+
+    assertThat(result.getModule().getModuleId()).isEqualTo(MODULE_FOO_ID);
+    verify(repository).findAllRequiredByModuleId(MODULE_FOO_ID);
+    verifyNoInteractions(applicationClosureResolver);
+  }
+
+  @Test
+  void getById_withBlankApplicationId_fallsBackToLegacyQuery() {
+    var moduleView = moduleBootstrapView(MODULE_FOO_ID, MODULE_FOO_INTERFACE_ID);
+    moduleView.setApplicationId("some-app-1.0.0");
+    when(repository.findAllRequiredByModuleId(MODULE_FOO_ID)).thenReturn(new ArrayList<>(List.of(moduleView)));
+
+    var result = service.getById(MODULE_FOO_ID, "   ");
+
+    assertThat(result.getModule().getModuleId()).isEqualTo(MODULE_FOO_ID);
+    verify(repository).findAllRequiredByModuleId(MODULE_FOO_ID);
+    verifyNoInteractions(applicationClosureResolver);
+  }
+
+  @Test
+  void getById_withApplicationId_emptyClosureFallsBackToLegacyQuery() {
+    var applicationId = "app-platform-minimal-2.0.53";
+    var moduleView = moduleBootstrapView(MODULE_FOO_ID, MODULE_FOO_INTERFACE_ID);
+
+    when(applicationClosureResolver.resolve(Set.of(applicationId))).thenReturn(Set.of());
+    when(repository.findAllRequiredByModuleId(MODULE_FOO_ID)).thenReturn(new ArrayList<>(List.of(moduleView)));
+
+    var result = service.getById(MODULE_FOO_ID, applicationId);
+
+    assertThat(result.getModule().getModuleId()).isEqualTo(MODULE_FOO_ID);
+    verify(applicationClosureResolver).resolve(Set.of(applicationId));
+    verify(repository).findAllRequiredByModuleId(MODULE_FOO_ID);
+    verifyNoMoreInteractions(repository);
   }
 
   @Test

--- a/src/test/java/org/folio/am/service/ModuleBootstrapServiceTest.java
+++ b/src/test/java/org/folio/am/service/ModuleBootstrapServiceTest.java
@@ -143,4 +143,39 @@ class ModuleBootstrapServiceTest {
     verify(repository).findAllRequiredByModuleId(MODULE_FOO_ID);
     verifyNoInteractions(applicationClosureResolver);
   }
+
+  @Test
+  void getById_withApplicationId_prefersSameApplicationModuleOverHigherVersion() {
+    var applicationId = "app-platform-minimal-2.0.53";
+    var otherAppId = "app-platform-complete-1.0.0";
+    var closure = Set.of(applicationId, otherAppId);
+
+    when(applicationClosureResolver.resolve(Set.of(applicationId))).thenReturn(closure);
+
+    // mod-users-keycloak-3.0.13 is the module being bootstrapped (in applicationId)
+    var keycloakView = moduleBootstrapView("mod-users-keycloak-3.0.13", "login");
+    keycloakView.setApplicationId(applicationId);
+    keycloakView.getDescriptor().addRequiresItem(new InterfaceReference().id("users"));
+    keycloakView.setLocation(null);
+
+    // mod-users-19.5.4 is in the preferred application (applicationId)
+    var users54View = moduleBootstrapView("mod-users-19.5.4", "users");
+    users54View.setApplicationId(applicationId);
+    users54View.setLocation("http://5-4");
+
+    // mod-users-19.6.0 is in the other application (higher version but not preferred)
+    var users60View = moduleBootstrapView("mod-users-19.6.0", "users");
+    users60View.setApplicationId(otherAppId);
+    users60View.setLocation("http://6-0");
+
+    when(repository.findAllRequiredByModuleIdAndApplicationIds(
+      "mod-users-keycloak-3.0.13", closure))
+      .thenReturn(new ArrayList<>(List.of(keycloakView, users54View, users60View)));
+
+    var result = service.getById("mod-users-keycloak-3.0.13", applicationId);
+
+    assertThat(result.getRequiredModules())
+      .extracting(org.folio.am.domain.dto.ModuleBootstrapDiscovery::getModuleId)
+      .containsExactly("mod-users-19.5.4");
+  }
 }

--- a/src/test/resources/sql/module-bootstrap/cross-app-collision.sql
+++ b/src/test/resources/sql/module-bootstrap/cross-app-collision.sql
@@ -1,0 +1,39 @@
+insert into application(id, name, version, application_descriptor)
+values
+  ('app-platform-minimal-2.0.53', 'app-platform-minimal', '2.0.53', '{
+    "id": "app-platform-minimal-2.0.53",
+    "name": "app-platform-minimal",
+    "version": "2.0.53",
+    "modules": [
+      {"id": "mod-users-keycloak-3.0.13", "name": "mod-users-keycloak", "version": "3.0.13"},
+      {"id": "mod-users-19.5.4", "name": "mod-users", "version": "19.5.4"}
+    ]
+  }'),
+  ('app-platform-complete-1.2.0', 'app-platform-complete', '1.2.0', '{
+    "id": "app-platform-complete-1.2.0",
+    "name": "app-platform-complete",
+    "version": "1.2.0",
+    "modules": [
+      {"id": "mod-users-19.6.0", "name": "mod-users", "version": "19.6.0"}
+    ]
+  }');
+
+INSERT INTO module(id, name, version, discovery_url, descriptor, type)
+VALUES
+  ('mod-users-keycloak-3.0.13', 'mod-users-keycloak', '3.0.13',
+   'http://mod-users-keycloak-3-0-13', '{}', 'BACKEND'),
+  ('mod-users-19.5.4', 'mod-users', '19.5.4',
+   'http://mod-users-19-5-4', '{}', 'BACKEND'),
+  ('mod-users-19.6.0', 'mod-users', '19.6.0',
+   'http://mod-users-19-6-0', '{}', 'BACKEND');
+
+INSERT INTO application_module(application_id, module_id)
+VALUES
+  ('app-platform-minimal-2.0.53', 'mod-users-keycloak-3.0.13'),
+  ('app-platform-minimal-2.0.53', 'mod-users-19.5.4'),
+  ('app-platform-complete-1.2.0', 'mod-users-19.6.0');
+
+insert into module_interface_reference(module_id, id, version, type) VALUES
+  ('mod-users-keycloak-3.0.13', 'users', '19.0', 'REQUIRES'),
+  ('mod-users-19.5.4', 'users', '19.5', 'PROVIDES'),
+  ('mod-users-19.6.0', 'users', '19.6', 'PROVIDES');

--- a/src/test/resources/sql/module-bootstrap/cross-app-collision.sql
+++ b/src/test/resources/sql/module-bootstrap/cross-app-collision.sql
@@ -21,11 +21,17 @@ values
 INSERT INTO module(id, name, version, discovery_url, descriptor, type)
 VALUES
   ('mod-users-keycloak-3.0.13', 'mod-users-keycloak', '3.0.13',
-   'http://mod-users-keycloak-3-0-13', '{}', 'BACKEND'),
+   'http://mod-users-keycloak-3-0-13',
+   '{"id":"mod-users-keycloak-3.0.13","requires":[{"id":"users","version":"19.0"}]}',
+   'BACKEND'),
   ('mod-users-19.5.4', 'mod-users', '19.5.4',
-   'http://mod-users-19-5-4', '{}', 'BACKEND'),
+   'http://mod-users-19-5-4',
+   '{"id":"mod-users-19.5.4","provides":[{"id":"users","version":"19.5"}]}',
+   'BACKEND'),
   ('mod-users-19.6.0', 'mod-users', '19.6.0',
-   'http://mod-users-19-6-0', '{}', 'BACKEND');
+   'http://mod-users-19-6-0',
+   '{"id":"mod-users-19.6.0","provides":[{"id":"users","version":"19.6"}]}',
+   'BACKEND');
 
 INSERT INTO application_module(application_id, module_id)
 VALUES


### PR DESCRIPTION
## EUREKASUP-156: Multi-version module deployment – application-scoped bootstrap

### Purpose

When multiple applications sharing the same module name (e.g. `mod-users`) are deployed in a single Eureka cluster, the module bootstrap endpoint returns providers from **all** applications indiscriminately, causing the sidecar to route to the wrong version. This change scopes bootstrap resolution to the transitive closure of a specific application, enabling correct per-application egress routing.

US: [EUREKASUP-156](https://folio-org.atlassian.net/browse/EUREKASUP-156)

### Approach

Added an optional `applicationId` query parameter to `GET /modules/{id}`. When provided, the repository query is restricted to modules belonging to the transitive closure of that application's dependency graph; when omitted, the existing all-applications behaviour is preserved for backwards compatibility.

**Implementation details:**

- Introduced `ApplicationClosureResolver` — a Spring `@Service` that performs a BFS walk over `application_descriptor.dependencies` JSONB, returning the full set of reachable application IDs including the root. Handles cycles and missing nodes gracefully.
- Added `ModuleBootstrapRepository.findAllRequiredByModuleIdAndApplicationIds` — a JPQL query equivalent to the existing `findAllRequiredByModuleId` with an extra `AND view.applicationId IN :applicationIds` clause.
- Changed `ModuleBootstrapService.getById` to accept an optional `applicationId`; when non-null it calls `ApplicationClosureResolver.resolve` and passes the resulting set to the new scoped query. The single-argument overload delegates to `getById(id, null)` for backwards compatibility.
- Hardened `deduplicateRequiredModules` to prefer modules belonging to the requested application over higher-semver candidates from other applications via `isBetterCandidate`, preventing cross-application version bleeding even if the closure widens.
- Added `applicationId` query parameter to `GET /modules/{id}` in `am.yaml`; regenerated OpenAPI stubs and updated `ModuleBootstrapController` to forward the parameter to the service.

### Pre-Review Checklist

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Dependent module build verification** — Ran manually when library changes impact downstream modules.
  > Actions → Verify Dependent Modules → Run workflow → select branch → Run.
- [x] **Breaking Changes (if any)** — Handled if changes affect integration with other services.
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.