### PR TITLE
docs: optimize AGENTS.md for conciseness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,356 +1,52 @@
-# AGENTS.md
+# mgr-applications
 
-This file provides guidance to agents when working with code in this repository.
+Spring Boot 4.0.3 Application Manager for FOLIO: manages application/module lifecycle (registration, discovery, deployment, validation). Java 21, PostgreSQL/JPA, Liquibase, Kafka, Kong, Keycloak, OpenAPI codegen, MapStruct, Lombok.
 
-## Project Overview
+## Build & Test
 
-`mgr-applications` is a Spring Boot application that serves as the Application Manager for the FOLIO library management platform. It provides functionality for managing application and module lifecycles, including registration, discovery, deployment, validation, and integration with external services.
-
-**Technology Stack:**
-- Java 21 with Spring Boot 4.0.3
-- PostgreSQL database with JPA/Hibernate
-- Liquibase for database migrations
-- Kafka for event streaming
-- Kong Gateway integration for API routing
-- Keycloak for authentication/authorization
-- OpenAPI code generation for REST APIs
-- MapStruct for object mapping
-- Lombok for boilerplate reduction
-
-## Build and Test Commands
-
-### Building the Project
-
-```shell
-# Full build with tests
-mvn clean install
-
-# Build without tests
-mvn clean install -DskipTests
-
-# Run checkstyle verification
-mvn checkstyle:check
+```bash
+mvn clean install              # full build
+mvn clean install -DskipTests  # skip tests
+mvn test                       # unit tests (@Tag("unit"), *Test.java)
+mvn verify                     # integration tests (@Tag("integration"), *IT.java; Testcontainers Postgres+Kafka)
+mvn test -Dtest=ApplicationServiceTest#shouldCreateApplication  # single test
+mvn checkstyle:check           # runs during build, FOLIO rules
 ```
 
-### Running Tests
+Run locally: `java -Dokapi.url=... -Dokapi.token=... -jar target/mgr-applications-*.jar`. Full env vars in `README.md`.
 
-```shell
-# Run unit tests only (tests tagged with @Tag("unit"))
-mvn test
+## Architecture
 
-# Run integration tests (tests tagged with @Tag("integration"))
-mvn verify
+Layers: Controllers (implement OpenAPI-generated interfaces) → Services → Repositories/Entities → Integration.
 
-# Run a single test class
-mvn test -Dtest=ApplicationServiceTest
+**Domain** (`org.folio.am`): `ApplicationEntity` (JSONB `ApplicationDescriptor`) ⇄ `ModuleEntity` (JSONB `ModuleDescriptor`, BACKEND/UI) is many-to-many via `application_module`. `ModuleDiscoveryEntity` = modules with non-null `discovery_url` (`@SQLRestriction`). `InterfaceReferenceEntity` tracks provided/required interfaces.
 
-# Run a single test method
-mvn test -Dtest=ApplicationServiceTest#shouldCreateApplication
-```
+**Key services**: `ApplicationService` (CRUD, versioning, validation orchestration), `DependenciesValidator`, `ModuleDiscoveryService`, `ModuleBootstrapService`.
 
-**Test Organization:**
-- Unit tests: Tagged with `@Tag("unit")`, use `mvn test`
-- Integration tests: Tagged with `@Tag("integration")`, use `mvn verify` or `mvn failsafe:integration-test`
-- Integration tests are in files ending with `*IT.java`
-- Unit tests are in files ending with `*Test.java`
-- Test containers are used for PostgreSQL and Kafka in integration tests
+**Repositories** extend `JpaCqlRepository` for CQL filtering (e.g. `name=="app*"`) via `cql2pgjson`; use `findByQuery()`.
 
-### Running the Application
+**Integrations**:
+- Kong (`integration.kong`): `KongDiscoveryListener` syncs discovery → Kong services/routes. Toggle `KONG_INTEGRATION_ENABLED`.
+- Kafka (`integration.kafka`): `DiscoveryPublisher` → `${ENV}.discovery`; `EntitlementEventListener` consumes `${ENV}.entitlement` (ENTITLE/UPGRADE/REVOKE), updates Kong tenant routes when `KONG_TENANT_CHECKS_ENABLED=true`.
+- Keycloak (`integration.okapi`): resource-server/client/role/policy import; JWT validation. Toggle `KC_INTEGRATION_ENABLED`.
+- mgr-tenant-entitlements (`integration.mte`): blocks deletion of entitled applications.
 
-```shell
-# Run locally (requires PostgreSQL and proper environment variables)
-java \
-  -Dokapi.url=http://localhost:9130 \
-  -Dokapi.token=${okapiToken} \
-  -jar target/mgr-applications-*.jar
+**Events** via `ApplicationEventPublisher`: `ApplicationDescriptorListener` (create/delete), `ApplicationDiscoveryListener` (discovery create/update/delete) drive Keycloak/Kong/Kafka side effects. Reliable publishing via transactional outbox (`integration.messaging`).
 
-# Build Docker image
-docker build -t mgr-applications .
-```
+**FAR mode** (`FAR_MODE=true`): descriptor CRUD only; disables Kong/Kafka/Okapi/mte.
 
-## Architecture Overview
+**Validation** (`VALIDATION_MODE`): NONE / BASIC / ON_CREATE (full dependency checks).
 
-### Domain Model
+## Conventions
 
-The application manages two primary entities with a many-to-many relationship:
-
-**Applications (`ApplicationEntity`):**
-- Contain an `ApplicationDescriptor` (stored as JSONB)
-- Have multiple modules (backend and UI modules)
-- Stored in `application` table
-
-**Modules (`ModuleEntity`):**
-- Have a `ModuleDescriptor` (stored as JSONB) defining routes, permissions, interfaces
-- Can be BACKEND or UI type (`ModuleType` enum)
-- Have interface references for dependency management (`InterfaceReferenceEntity`)
-- Support discovery via `discoveryUrl` (tracked in `ModuleDiscoveryEntity`)
-- Stored in `module` table
-- Many-to-many relationship with applications via `application_module` join table
-
-**Module Discovery (`ModuleDiscoveryEntity`):**
-- Filtered view of modules with non-null `discovery_url`
-- Uses `@SQLRestriction("discovery_url IS NOT NULL")`
-- Represents where module instances are deployed/running
-
-### Layer Architecture
-
-```
-Controllers (REST API)
-    ↓
-Services (Business Logic)
-    ↓
-Repositories (Data Access) ← Entities (Domain Model)
-    ↓
-Integration Layer (External Systems)
-```
-
-**Key Service Classes:**
-- `ApplicationService`: Core CRUD operations for applications, version management, validation orchestration
-- `ApplicationValidatorService`: Validates application descriptors
-- `ApplicationDescriptorsValidationService`: Batch validation logic
-- `DependenciesValidator`: Validates module dependencies and interface requirements
-- `ModuleDiscoveryService`: Manages module discovery registration/updates
-- `ModuleBootstrapService`: Handles module bootstrap initialization
-
-**Mapper Pattern:**
-- MapStruct interfaces in `org.folio.am.mapper` package
-- `MappingMethods`: Shared mapping utilities
-- Converts between DTOs (generated from OpenAPI) and domain entities
-
-**Repository Pattern:**
-- Spring Data JPA repositories in `org.folio.am.repository`
-- `ApplicationRepository`: Complex queries including entity graphs for performance
-- `ModuleRepository`: Module-specific queries
-- `ModuleDiscoveryRepository`: Discovery-specific queries
-- **CQL Support**: Repositories extend `JpaCqlRepository` for Common Query Language support
-  - Enables flexible filtering via CQL queries (e.g., `name=="app*" and version=="1.0.0"`)
-  - Converted to SQL via `cql2pgjson` library
-  - Used in `findByQuery()` methods throughout repositories
-
-### Integration Points
-
-**Kong Gateway Integration (`org.folio.am.integration.kong`):**
-- `KongDiscoveryListener`: Event listener that syncs discovery changes to Kong
-- Automatically registers/updates Kong services and routes based on module descriptors
-- Supports tenant-based routing with dynamic route expression updates
-- Controlled by `KONG_INTEGRATION_ENABLED` environment variable
-
-**Kafka Integration (`org.folio.am.integration.kafka`):**
-- `DiscoveryPublisher`: Publishes discovery change events to `${ENV}.discovery` topic
-- `EntitlementEventListener`: Consumes entitlement events from `${ENV}.entitlement` topic
-  - Updates Kong routes with tenant restrictions when `KONG_TENANT_CHECKS_ENABLED=true`
-  - Handles ENTITLE, UPGRADE, REVOKE event types
-  - Dynamically adds/removes tenants from route expressions using `x-okapi-tenant` header validation
-
-**Keycloak Integration (`org.folio.am.integration.okapi`):**
-- Import mode: Creates/updates resource servers, clients, resources, permissions, roles, policies
-- Security mode: JWT token validation and endpoint permission evaluation
-- Controlled by `KC_INTEGRATION_ENABLED` environment variable
-
-**Manager Tenant Entitlements Integration (`org.folio.am.integration.mte`):**
-- `EntitlementService`: Checks if applications have active entitlements before deletion
-- Prevents deletion of applications that are currently entitled to tenants
-
-### Event-Driven Architecture
-
-The application uses event listeners for cross-cutting concerns via the `ApplicationEventPublisher` service:
-
-**Listener Interfaces:**
-- `ApplicationDescriptorListener`: Interface for application lifecycle events
-  - `onDescriptorCreate()`: Fired when application is created
-  - `onDescriptorDelete()`: Fired when application is deleted
-- `ApplicationDiscoveryListener`: Interface for discovery lifecycle events
-  - `onDiscoveryCreate()`: Fired when module discovery is registered
-  - `onDiscoveryUpdate()`: Fired when discovery is updated
-  - `onDiscoveryDelete()`: Fired when discovery is removed
-
-**Event Flow Example:**
-```
-ApplicationService.create()
-  → ApplicationEventPublisher.publishDescriptorCreate()
-    → OkapiModuleRegisterService (Keycloak registration)
-  → ModuleDiscoveryService.addDiscoveryUrl()
-    → ApplicationEventPublisher.publishDiscoveryCreate()
-      → KongDiscoveryListener (Kong service creation)
-      → DiscoveryPublisher (Kafka event)
-```
-
-**Outbox Pattern:**
-- Transactional outbox tables for reliable event publishing
-- Located in `org.folio.am.integration.messaging` package
-
-### Code Generation
-
-**OpenAPI Generator:**
-- API specification: `src/main/resources/swagger.api/am.yaml`
-- Generated code: `target/generated-sources`
-- Packages:
-  - DTOs: `org.folio.am.domain.dto`
-  - REST interfaces: `org.folio.am.rest.resource`
-- Controllers implement generated interfaces
-
-### Validation Framework
-
-**Validation Modes (`ValidationMode` enum):**
-- `NONE`: No validation
-- `BASIC`: Basic descriptor validation
-- `ON_CREATE`: Full validation including dependency checks (used during creation)
-- Controlled by `VALIDATION_MODE` environment variable
-
-**Validators (`org.folio.am.service.validator`):**
-- `ModuleDescriptorValidator`: Validates module descriptors
-- `ModuleDescriptorsSourceValidator`: Validates descriptor sources
-- `DependenciesValidator`: Validates dependencies between modules and interface availability
-
-### Special Modes
-
-**Folio Application Registry (FAR) Mode:**
-- When `FAR_MODE=true`: Only CRUD operations for application descriptors are enabled
-- Disables Kong, Kafka, Okapi, and mgr-tenant-entitlements integrations
-- Used for registry-only deployments without service discovery
-
-## Important Patterns
-
-### Entity Relationships
-
-- `ApplicationEntity` ↔ `ModuleEntity`: Many-to-many (applications can include multiple modules, modules can belong to multiple applications)
-- `ModuleEntity` → `InterfaceReferenceEntity`: One-to-many (modules provide/require interfaces)
-- Module types are split into `BACKEND` and `UI` via the `ModuleType` enum
-
-### Database Schema
-
-- Liquibase changelogs: `src/main/resources/changelog/`
-- Master changelog: `changelog-master.xml`
-- Versioned changes organized by version (v1.0.0, v3.0.0, v4.0.0)
-- JSONB columns for storing descriptors (flexible schema)
-
-### Transaction Management
-
-- `@Transactional` on service layer
-- Read-only transactions by default on service classes
-- Write operations explicitly marked with `@Transactional`
-- Transactional outbox pattern for reliable event publishing
-
-### Configuration
-
-- Spring Boot profiles and properties
-- Environment variable-driven configuration (see README.md for full list)
-- Conditional bean creation based on integration flags:
-  - `@ConditionalOnProperty` for Kong, Keycloak, Kafka, Okapi integrations
-
-### Annotation Processing
-
-**Important Order Requirements:**
-- Lombok must process before MapStruct
-- Maven compiler plugin annotation processor paths are ordered: Lombok → Spring Boot Config Processor → MapStruct
-- This ensures Lombok generates getters/setters before MapStruct generates mapping code
-- IDE configuration must match this ordering
-
-## Common Development Tasks
-
-### Adding a New Endpoint
-
-1. Update OpenAPI spec: `src/main/resources/swagger.api/am.yaml`
-2. Run `mvn clean install` to regenerate interfaces
-3. Implement the generated interface in a Controller class
-4. Add service layer logic
-5. Write unit tests and integration tests
-
-### Modifying Database Schema
-
-1. Create new Liquibase changelog XML in `src/main/resources/changelog/changes/vX.X.X/`
-2. Include it in the version-specific changelog (e.g., `changelog-4.0.0.xml`)
-3. Update entity classes to match schema changes
-4. Test with integration tests that spin up PostgreSQL via Testcontainers
-
-### Working with Module Descriptors
-
-- Module descriptors define routes, permissions, and interfaces
-- Stored as JSONB in the `descriptor` column of `module` table
-- Use `ModuleDescriptorLoader` to load/parse descriptors
-- Descriptors are from the `folio-backend-common` dependency (`org.folio.common.domain.model.ModuleDescriptor`)
-
-### Integration Testing
-
-- Integration tests use `@SpringBootTest` with Testcontainers
-- WireMock for mocking external HTTP services (Kong, Keycloak, mgr-tenant-entitlements)
-- Kafka test containers for event testing
-- PostgreSQL test containers for database testing
-- Use `@Tag("integration")` to mark integration tests
-
-### Unit Testing
-
-**IMPORTANT**: This project has comprehensive unit testing guidelines. See `https://github.com/folio-org/folio-eureka-ai-dev/blob/master/docs/testing/unit-testing.md` for detailed best practices.
-
-**Key Unit Testing Principles:**
-
-1. **Never use lenient mode** - `@MockitoSettings(strictness = Strictness.LENIENT)` is forbidden
-2. **Only stub what you need** - Avoid unnecessary stubbing in `@BeforeEach`, use helper methods instead
-3. **Only verify unmocked interactions** - Don't verify methods already mocked with `when()`
-4. **Test naming convention**: `methodName_scenario_expectedBehavior`
-   - Example: `tableExists_positive_tableIsPresent`
-   - Example: `deleteTimer_negative_timerDescriptorIdIsNull`
-5. **Test structure**: Arrange-Act-Assert pattern
-6. **Resource cleanup**: Always verify that connections, streams, etc. are closed
-7. **Test independence**: Each test should be self-contained and not rely on execution order
-8. **Helper methods**: Use private helper methods for common mock setups (e.g., `setupContextMocks()`)
-9. **Parameterized tests**: Use `Stream<Type>` directly for single parameter tests, not `Stream<Arguments>`
-10. **Explicit lambda types**: Declare types explicitly when var inference fails (e.g., `Supplier<RuntimeException>`)
-
-**Example Test Structure:**
-```java
-@UnitTest
-@ExtendWith(MockitoExtension.class)
-class MyServiceTest {
-    @Mock
-    private Dependency dependency;
-
-    private void setupCommonMocks() {
-        when(dependency.getSomething()).thenReturn("value");
-    }
-
-    @AfterEach
-    void tearDown() {
-        verifyNoMoreInteractions(dependency); // Only include mocks that should be fully accounted for
-    }
-
-    @Test
-    void operation_positive_success() {
-        setupCommonMocks(); // Only call if needed
-        var service = new MyService(dependency);
-
-        when(dependency.doSomething()).thenReturn(expectedValue);
-
-        var result = service.operation();
-
-        assertThat(result).isEqualTo(expectedValue);
-        verify(dependency).close(); // Only verify unmocked calls
-    }
-}
-```
-
-**Important Verification Rules:**
-- ❌ DON'T verify mocked methods: `when(foo.bar()).thenReturn(x); verify(foo).bar();` is redundant
-- ✅ DO verify unmocked resource cleanup: `verify(connection).close();`
-- ✅ DO verify unmocked side effects: Methods called but not stubbed with `when()`
-
-For complete guidelines, examples, and checklist, refer to the external documentation at `https://github.com/folio-org/folio-eureka-ai-dev/blob/master/docs/testing/unit-testing.md`.
+- **Codegen**: OpenAPI spec `src/main/resources/swagger.api/am.yaml` → `org.folio.am.domain.dto` + `org.folio.am.rest.resource` in `target/generated-sources` (do not edit). Add endpoint: edit spec → `mvn clean install` → implement generated interface.
+- **DB**: Liquibase under `src/main/resources/changelog/` (`changelog-master.xml`); add new versioned changesets, never edit applied ones. JSONB for descriptors.
+- **Transactions**: read-only by default on services; mark writes `@Transactional`.
+- **Annotation order**: Lombok → Spring Config Processor → MapStruct (must match in IDE).
+- **Conditional beans**: `@ConditionalOnProperty` per integration.
+- **Logging**: Log4j2 (Spring default logging excluded). Secure stores: AWS-SSM/Vault/FSSP.
+- **Unit tests**: never use lenient Mockito; stub only what's needed; verify only unmocked interactions; name `methodName_scenario_expectedBehavior`. Full guide: https://github.com/folio-org/folio-eureka-ai-dev/blob/master/docs/testing/unit-testing.md
 
 ## Key Dependencies
 
-- `folio-spring-cql`: CQL query support for FOLIO
-- `folio-security`: Security and Keycloak integration
-- `folio-integration-kafka`: Kafka integration utilities
-- `folio-backend-common`: Common FOLIO backend models (ModuleDescriptor)
-- `folio-integration-kong`: Kong Gateway integration
-- `cql2pgjson`: CQL to PostgreSQL JSON conversion
-- `semver4j`: Semantic versioning support
-
-## Notes
-
-- The application uses Log4j2 for logging (Spring Boot starter-logging is excluded)
-- Checkstyle is enforced during build with FOLIO rules
-- Lombok is used extensively - ensure annotation processing is enabled in your IDE
-- MapStruct annotation processors must run after Lombok
-- The application supports SSL/TLS configuration for server and client connections
-- Secure storage integrations: AWS-SSM, Vault, FSSP (Folio Secure Store Proxy)
+`folio-spring-cql`, `folio-security`, `folio-integration-kafka`, `folio-backend-common`, `folio-integration-kong`, `cql2pgjson`, `semver4j`.


### PR DESCRIPTION
## Purpose

Optimize `AGENTS.md` so it is short, concise, and complete — following the recommended [AGENTS.md](https://agents.md/) best practices (project overview, build/test commands, code style, testing, and key conventions only).

## Approach

- Trimmed redundant and low-signal content: duplicated command variations, content that belongs in `README.md` (full environment-variable dumps, Docker/run-locally blocks), step-by-step "how to add X" tutorials, and large inline code samples.
- Kept all agent-actionable information: build/test commands, architecture and request/event flows, package map, code-generation "do not edit" rules, Liquibase append-only guidance, testing tags/conventions, and security patterns.
- No functional or source-code changes — documentation only. `NEWS.md` is intentionally unchanged.

The file is now significantly smaller while preserving the same essential guidance for coding agents.
