### PR TITLE
EUREKA-899: POC - Application-scoped sidecars bootstrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ build/
 .claude/
 .codemie/
 CLAUDE.md
+/.codegraph/

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ## Version `v4.1.0` (IN PROGRESS)
 * Allow interface to be both provided and require / optional in the same module descriptor (MGRAPPS-99)
 * Upgrade dependencies for Kafka 4.2 compatibility in mgr-applications (MGRAPPS-110)
+* Application-scoped sidecar bootstrap: ingress and egress module-bootstrap endpoints (EUREKA-899)
 
 ---
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -7,3 +7,4 @@ This directory contains behavioral feature documentation for the Manager Applica
 - [kong-route-management](features/kong-route-management.md) - Kong Gateway Route Management
 - [Application Discovery](features/application-discovery.md) - Query module deployment locations organized by application
 - [Application Cleanup](features/application-cleanup.md) - Remove unused application descriptors and return a cleanup summary
+- [Module Bootstrap](features/module-bootstrap.md) - Ingress (own routes) and application-scoped egress bootstrap for module sidecars

--- a/docs/features/module-bootstrap.md
+++ b/docs/features/module-bootstrap.md
@@ -31,7 +31,3 @@ The pre-existing `GET /modules/{id}` (full, globally-resolved bootstrap) is unch
 - Required modules are filtered to the interfaces the module actually requires/optional, and deduplicated by name keeping the highest version (same as `GET /modules/{id}`).
 - Scoping is applied in SQL over the existing `v_module_bootstrap` view; there is no tenant context or DB-view change.
 
-## Out of scope
-
-- Caching of scoped results (tracked separately).
-- Sidecar-side changes (entitled-application lookup, per-tenant route tables, refresh on entitlement change).

--- a/docs/features/module-bootstrap.md
+++ b/docs/features/module-bootstrap.md
@@ -1,0 +1,37 @@
+---
+feature_id: module-bootstrap
+title: Module Bootstrap (Ingress and Scoped Egress)
+updated: 2026-06-17
+---
+
+# Module Bootstrap (Ingress and Scoped Egress)
+
+## What it does
+
+Adds two endpoints used by the FOLIO module sidecar to build its routing tables:
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | /modules/{id}/bootstrap | Ingress: the module's own discovery and provided routes only (empty `requiredModules`). |
+| POST | /modules/{id}/bootstrap | Egress: discovery for the module's required/optional providers, restricted to the application scope in the request body. |
+
+The pre-existing `GET /modules/{id}` (full, globally-resolved bootstrap) is unchanged.
+
+## Request / response
+
+- **Egress request** (`egressBootstrapRequest`): `{ "applicationIds": ["app-a-1.0.0", ...] }` (required, at least one id).
+- **Ingress response**: `moduleBootstrap` with `module` populated and `requiredModules: []`.
+- **Egress response** (`egressBootstrap`): `{ "requiredModules": [...] }` — providers resolved within the supplied applications only; the self module is not returned.
+
+## Business rules
+
+- Egress required-module resolution only considers providers whose owning application is in `applicationIds`.
+- If the requested module is not present in the supplied scope, egress returns `404`.
+- Empty/missing `applicationIds` returns `400`.
+- Required modules are filtered to the interfaces the module actually requires/optional, and deduplicated by name keeping the highest version (same as `GET /modules/{id}`).
+- Scoping is applied in SQL over the existing `v_module_bootstrap` view; there is no tenant context or DB-view change.
+
+## Out of scope
+
+- Caching of scoped results (tracked separately).
+- Sidecar-side changes (entitled-application lookup, per-tenant route tables, refresh on entitlement change).

--- a/src/main/java/org/folio/am/controller/ModuleBootstrapController.java
+++ b/src/main/java/org/folio/am/controller/ModuleBootstrapController.java
@@ -1,6 +1,8 @@
 package org.folio.am.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.folio.am.domain.dto.EgressBootstrap;
+import org.folio.am.domain.dto.EgressBootstrapRequest;
 import org.folio.am.domain.dto.ModuleBootstrap;
 import org.folio.am.rest.resource.ModuleBootstrapApi;
 import org.folio.am.service.ModuleBootstrapService;
@@ -18,5 +20,15 @@ public class ModuleBootstrapController extends BaseController implements ModuleB
     var moduleBootstrap = service.getById(id);
 
     return ResponseEntity.ok(moduleBootstrap);
+  }
+
+  @Override
+  public ResponseEntity<ModuleBootstrap> getModuleIngressBootstrap(String id) {
+    return ResponseEntity.ok(service.getIngressBootstrap(id));
+  }
+
+  @Override
+  public ResponseEntity<EgressBootstrap> getModuleEgressBootstrap(String id, EgressBootstrapRequest request) {
+    return ResponseEntity.ok(service.getEgressBootstrap(id, request.getApplicationIds()));
   }
 }

--- a/src/main/java/org/folio/am/repository/ModuleBootstrapRepository.java
+++ b/src/main/java/org/folio/am/repository/ModuleBootstrapRepository.java
@@ -13,10 +13,14 @@ public interface ModuleBootstrapRepository extends JpaRepository<ModuleBootstrap
   /**
    * Queries the module and all its dependencies by the given id.
    *
+   * <p>No {@code DISTINCT} is used: the {@code v_module_bootstrap} grain is one row per (module, application) —
+   * guaranteed by the {@code application_module} composite primary key — and the nested {@code IN} subqueries are
+   * semi-joins that cannot fan out rows, so duplicates are not possible.</p>
+   *
    * @param moduleId the module identifier
    * @return List of module views
    */
-  @Query(value = "SELECT DISTINCT view FROM ModuleBootstrapView view WHERE (view.id = :moduleId OR view.id IN "
+  @Query(value = "SELECT view FROM ModuleBootstrapView view WHERE (view.id = :moduleId OR view.id IN "
     + "(SELECT p.moduleId FROM InterfaceReferenceEntity p WHERE p.type = 'PROVIDES' AND "
     + "p.id IN (SELECT r.id FROM InterfaceReferenceEntity r WHERE r.moduleId = :moduleId AND "
     + "(r.type = 'REQUIRES' OR r.type = 'OPTIONAL')))) and (view.location is not null OR view.id = :moduleId)")
@@ -31,7 +35,7 @@ public interface ModuleBootstrapRepository extends JpaRepository<ModuleBootstrap
    * @param applicationIds the application scope
    * @return List of in-scope module views
    */
-  @Query(value = "SELECT DISTINCT view FROM ModuleBootstrapView view WHERE view.applicationId IN :applicationIds "
+  @Query(value = "SELECT view FROM ModuleBootstrapView view WHERE view.applicationId IN :applicationIds "
     + "AND (view.id = :moduleId OR view.id IN "
     + "(SELECT p.moduleId FROM InterfaceReferenceEntity p WHERE p.type = 'PROVIDES' AND "
     + "p.id IN (SELECT r.id FROM InterfaceReferenceEntity r WHERE r.moduleId = :moduleId AND "

--- a/src/main/java/org/folio/am/repository/ModuleBootstrapRepository.java
+++ b/src/main/java/org/folio/am/repository/ModuleBootstrapRepository.java
@@ -21,4 +21,31 @@ public interface ModuleBootstrapRepository extends JpaRepository<ModuleBootstrap
     + "p.id IN (SELECT r.id FROM InterfaceReferenceEntity r WHERE r.moduleId = :moduleId AND "
     + "(r.type = 'REQUIRES' OR r.type = 'OPTIONAL')))) and (view.location is not null OR view.id = :moduleId)")
   List<ModuleBootstrapView> findAllRequiredByModuleId(@Param("moduleId") String moduleId);
+
+  /**
+   * Same as {@link #findAllRequiredByModuleId(String)} but restricted to the given application scope: only the
+   * module and provider rows whose application is in {@code applicationIds} are returned. When the module itself is
+   * not in scope no self row is returned.
+   *
+   * @param moduleId the module identifier
+   * @param applicationIds the application scope
+   * @return List of in-scope module views
+   */
+  @Query(value = "SELECT DISTINCT view FROM ModuleBootstrapView view WHERE view.applicationId IN :applicationIds "
+    + "AND (view.id = :moduleId OR view.id IN "
+    + "(SELECT p.moduleId FROM InterfaceReferenceEntity p WHERE p.type = 'PROVIDES' AND "
+    + "p.id IN (SELECT r.id FROM InterfaceReferenceEntity r WHERE r.moduleId = :moduleId AND "
+    + "(r.type = 'REQUIRES' OR r.type = 'OPTIONAL')))) and (view.location is not null OR view.id = :moduleId)")
+  List<ModuleBootstrapView> findAllRequiredByModuleIdAndApplicationIdsIn(
+    @Param("moduleId") String moduleId, @Param("applicationIds") List<String> applicationIds);
+
+  /**
+   * Returns the bootstrap view row(s) for a single module id. A list is returned (not Optional) because the same
+   * module id can appear once per owning application.
+   *
+   * @param moduleId the module identifier
+   * @return the module's own view row(s)
+   */
+  @Query(value = "SELECT view FROM ModuleBootstrapView view WHERE view.id = :moduleId")
+  List<ModuleBootstrapView> findViewsById(@Param("moduleId") String moduleId);
 }

--- a/src/main/java/org/folio/am/service/ModuleBootstrapService.java
+++ b/src/main/java/org/folio/am/service/ModuleBootstrapService.java
@@ -12,6 +12,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
+import org.folio.am.domain.dto.EgressBootstrap;
 import org.folio.am.domain.dto.ModuleBootstrap;
 import org.folio.am.domain.dto.ModuleBootstrapDiscovery;
 import org.folio.am.domain.entity.ModuleBootstrapView;
@@ -42,18 +43,43 @@ public class ModuleBootstrapService {
   @Transactional(readOnly = true)
   public ModuleBootstrap getById(String moduleId) {
     var views = repository.findAllRequiredByModuleId(moduleId);
-
     var moduleView = removeModuleViewById(moduleId, views);
-    var module = mapper.convert(moduleView);
+    return new ModuleBootstrap()
+      .module(mapper.convert(moduleView))
+      .requiredModules(resolveRequiredModules(moduleView, views));
+  }
 
+  /**
+   * Ingress bootstrap: the module's own routes only, with no dependency resolution.
+   */
+  @Transactional(readOnly = true)
+  public ModuleBootstrap getIngressBootstrap(String moduleId) {
+    var views = repository.findViewsById(moduleId);
+    if (views.isEmpty()) {
+      throw new EntityNotFoundException("Module not found by id: " + moduleId);
+    }
+    return new ModuleBootstrap()
+      .module(mapper.convert(views.get(0)))
+      .requiredModules(List.of());
+  }
+
+  /**
+   * Egress bootstrap: the required/optional providers resolved only within the supplied application scope. The
+   * self module is used to derive the required interfaces and to confirm scope membership, but is not returned.
+   */
+  @Transactional(readOnly = true)
+  public EgressBootstrap getEgressBootstrap(String moduleId, List<String> applicationIds) {
+    var views = repository.findAllRequiredByModuleIdAndApplicationIdsIn(moduleId, applicationIds);
+    var moduleView = removeModuleViewById(moduleId, views);
+    return new EgressBootstrap()
+      .requiredModules(resolveRequiredModules(moduleView, views));
+  }
+
+  private List<ModuleBootstrapDiscovery> resolveRequiredModules(ModuleBootstrapView moduleView,
+    List<ModuleBootstrapView> views) {
     var requiredInterfaces = getRequiredOptionalInterfaces(moduleView);
     var requiredModules = toModuleDiscoveries(requiredInterfaces, views);
-
-    requiredModules = deduplicateRequiredModules(requiredModules);
-
-    return new ModuleBootstrap()
-      .module(module)
-      .requiredModules(requiredModules);
+    return deduplicateRequiredModules(requiredModules);
   }
 
   private List<ModuleBootstrapDiscovery> deduplicateRequiredModules(List<ModuleBootstrapDiscovery> requiredModules) {

--- a/src/main/resources/descriptors/ModuleDescriptor.json
+++ b/src/main/resources/descriptors/ModuleDescriptor.json
@@ -127,6 +127,18 @@
           "methods": [ "GET" ],
           "pathPattern": "/modules/{id}",
           "permissionsRequired": [ "mgr-applications.module-bootstraps.item.get" ]
+        },
+        {
+          "type": "internal",
+          "methods": [ "GET" ],
+          "pathPattern": "/modules/{id}/bootstrap",
+          "permissionsRequired": [ "mgr-applications.module-bootstraps.item.get" ]
+        },
+        {
+          "type": "internal",
+          "methods": [ "POST" ],
+          "pathPattern": "/modules/{id}/bootstrap",
+          "permissionsRequired": [ "mgr-applications.module-bootstraps.item.post" ]
         }
       ]
     }
@@ -259,6 +271,11 @@
       "permissionName": "mgr-applications.module-bootstraps.item.get"
     },
     {
+      "description": "Post module bootstrap",
+      "displayName": "Manager Applications - post module bootstrap",
+      "permissionName": "mgr-applications.module-bootstraps.item.post"
+    },
+    {
       "description": "Manage applications",
       "displayName": "Manager Applications - Manage applications",
       "permissionName": "mgr-applications.applications.all",
@@ -303,7 +320,8 @@
         "mgr-applications.discoveries.collection.get",
         "mgr-applications.app-discoveries.collection.get",
         "mgr-applications.app-discoveries.item.get",
-        "mgr-applications.module-bootstraps.item.get"
+        "mgr-applications.module-bootstraps.item.get",
+        "mgr-applications.module-bootstraps.item.post"
       ]
     },
     {
@@ -314,7 +332,8 @@
       "subPermissions": [
         "mgr-applications.applications.all",
         "mgr-applications.discoveries.all",
-        "mgr-applications.module-bootstraps.item.get"
+        "mgr-applications.module-bootstraps.item.get",
+        "mgr-applications.module-bootstraps.item.post"
       ]
     }
   ]

--- a/src/main/resources/descriptors/ModuleDescriptor.json
+++ b/src/main/resources/descriptors/ModuleDescriptor.json
@@ -120,7 +120,7 @@
     },
     {
       "id": "module-bootstraps",
-      "version": "1.2",
+      "version": "1.3",
       "handlers": [
         {
           "type": "internal",

--- a/src/main/resources/swagger.api/am.yaml
+++ b/src/main/resources/swagger.api/am.yaml
@@ -250,6 +250,52 @@ paths:
         '500':
           $ref: '#/components/responses/internal-server-error'
 
+  /modules/{id}/bootstrap:
+    get:
+      operationId: getModuleIngressBootstrap
+      description: Retrieve ingress bootstrap (the module's own routes only) for the module referenced by id
+      tags:
+        - module-bootstrap
+      parameters:
+        - $ref: '#/components/parameters/path-entity-id'
+      responses:
+        '200':
+          description: Ingress bootstrap info (module with empty requiredModules)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/moduleBootstrap'
+        '404':
+          $ref: '#/components/responses/entity-not-found'
+        '500':
+          $ref: '#/components/responses/internal-server-error'
+    post:
+      operationId: getModuleEgressBootstrap
+      description: Retrieve egress bootstrap (required/optional modules) for the module referenced by id, restricted to the supplied application scope
+      tags:
+        - module-bootstrap
+      parameters:
+        - $ref: '#/components/parameters/path-entity-id'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/egressBootstrapRequest'
+      responses:
+        '200':
+          description: Egress bootstrap result scoped to the supplied applicationIds
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/egressBootstrap'
+        '400':
+          $ref: '#/components/responses/bad-request'
+        '404':
+          $ref: '#/components/responses/entity-not-found'
+        '500':
+          $ref: '#/components/responses/internal-server-error'
+
   /modules/discovery:
     get:
       operationId: searchModuleDiscovery
@@ -402,6 +448,10 @@ components:
       $ref: schemas/module/moduleDiscoveries.json
     moduleBootstrap:
       $ref: schemas/module/bootstrap/moduleBootstrap.json
+    egressBootstrapRequest:
+      $ref: schemas/module/bootstrap/egressBootstrapRequest.json
+    egressBootstrap:
+      $ref: schemas/module/bootstrap/egressBootstrap.json
     errorResponse:
       $ref: schemas/common/errors.json
     deploymentDescriptor:

--- a/src/main/resources/swagger.api/schemas/module/bootstrap/egressBootstrap.json
+++ b/src/main/resources/swagger.api/schemas/module/bootstrap/egressBootstrap.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Egress bootstrap: discovery information for the required/optional modules, resolved within a requested application scope.",
+  "properties": {
+    "requiredModules": {
+      "description": "Discovery information for the required/optional modules within scope",
+      "type": "array",
+      "items": { "$ref": "moduleBootstrapDiscovery.json" }
+    }
+  },
+  "required": ["requiredModules"]
+}

--- a/src/main/resources/swagger.api/schemas/module/bootstrap/egressBootstrapRequest.json
+++ b/src/main/resources/swagger.api/schemas/module/bootstrap/egressBootstrapRequest.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Request for egress module bootstrap. Required-module resolution is restricted to providers within the supplied application scope.",
+  "properties": {
+    "applicationIds": {
+      "description": "Application IDs that define the egress resolution scope.",
+      "type": "array",
+      "items": { "type": "string" },
+      "minItems": 1
+    }
+  },
+  "required": ["applicationIds"]
+}

--- a/src/test/java/org/folio/am/controller/ModuleBootstrapControllerTest.java
+++ b/src/test/java/org/folio/am/controller/ModuleBootstrapControllerTest.java
@@ -13,12 +13,18 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import jakarta.persistence.EntityNotFoundException;
+import java.util.List;
+import org.folio.am.domain.dto.EgressBootstrap;
+import org.folio.am.domain.dto.EgressBootstrapRequest;
 import org.folio.am.domain.dto.ModuleBootstrap;
+import org.folio.am.domain.dto.ModuleBootstrapDiscovery;
 import org.folio.am.service.ModuleBootstrapService;
+import org.folio.test.TestUtils;
 import org.folio.test.types.UnitTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,6 +43,7 @@ import org.springframework.test.web.servlet.MockMvc;
 class ModuleBootstrapControllerTest {
 
   private static final String ENDPOINT_PATH = "/modules/{id}";
+  private static final String BOOTSTRAP_PATH = "/modules/{id}/bootstrap";
 
   @Autowired private MockMvc mockMvc;
   @MockitoBean private ModuleBootstrapService service;
@@ -69,5 +76,56 @@ class ModuleBootstrapControllerTest {
       .andExpect(jsonPath("$.errors[0].message", is(errorMessage)))
       .andExpect(jsonPath("$.errors[0].type", is("EntityNotFoundException")))
       .andExpect(jsonPath("$.errors[0].code", is("not_found_error")));
+  }
+
+  @Test
+  void getModuleIngressBootstrap_positive() throws Exception {
+    var module = moduleBootstrapDiscovery(MODULE_FOO_ID, MODULE_FOO_INTERFACE_ID);
+    var expected = new ModuleBootstrap().module(module).requiredModules(List.of());
+    when(service.getIngressBootstrap(MODULE_FOO_ID)).thenReturn(expected);
+
+    var mvcResult = mockMvc.perform(get(BOOTSTRAP_PATH, MODULE_FOO_ID)
+        .contentType(APPLICATION_JSON))
+      .andExpect(status().isOk())
+      .andReturn();
+
+    assertThat(parseResponse(mvcResult, ModuleBootstrap.class)).isEqualTo(expected);
+  }
+
+  @Test
+  void getModuleEgressBootstrap_positive() throws Exception {
+    var requiredModule = moduleBootstrapDiscovery(MODULE_BAR_ID, MODULE_BAR_INTERFACE_ID);
+    var expected = new EgressBootstrap().requiredModules(List.of(requiredModule));
+    when(service.getEgressBootstrap(MODULE_FOO_ID, List.of("test-app-1.0.0"))).thenReturn(expected);
+
+    var mvcResult = mockMvc.perform(post(BOOTSTRAP_PATH, MODULE_FOO_ID)
+        .contentType(APPLICATION_JSON)
+        .content(TestUtils.asJsonString(new EgressBootstrapRequest().applicationIds(List.of("test-app-1.0.0")))))
+      .andExpect(status().isOk())
+      .andReturn();
+
+    assertThat(parseResponse(mvcResult, EgressBootstrap.class)).isEqualTo(expected);
+  }
+
+  @Test
+  void getModuleEgressBootstrap_negative_emptyApplicationIds() throws Exception {
+    mockMvc.perform(post(BOOTSTRAP_PATH, MODULE_FOO_ID)
+        .contentType(APPLICATION_JSON)
+        .content(TestUtils.asJsonString(new EgressBootstrapRequest().applicationIds(List.of()))))
+      .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void getModuleEgressBootstrap_negative_notFound() throws Exception {
+    var errorMessage = "Module not found by id: " + MODULE_FOO_ID;
+    when(service.getEgressBootstrap(MODULE_FOO_ID, List.of("test-app-1.0.0")))
+      .thenThrow(new EntityNotFoundException(errorMessage));
+
+    mockMvc.perform(post(BOOTSTRAP_PATH, MODULE_FOO_ID)
+        .contentType(APPLICATION_JSON)
+        .content(TestUtils.asJsonString(new EgressBootstrapRequest().applicationIds(List.of("test-app-1.0.0")))))
+      .andExpect(status().isNotFound())
+      .andExpect(jsonPath("$.errors[0].message", is(errorMessage)))
+      .andExpect(jsonPath("$.errors[0].type", is("EntityNotFoundException")));
   }
 }

--- a/src/test/java/org/folio/am/controller/ModuleBootstrapControllerTest.java
+++ b/src/test/java/org/folio/am/controller/ModuleBootstrapControllerTest.java
@@ -22,7 +22,6 @@ import java.util.List;
 import org.folio.am.domain.dto.EgressBootstrap;
 import org.folio.am.domain.dto.EgressBootstrapRequest;
 import org.folio.am.domain.dto.ModuleBootstrap;
-import org.folio.am.domain.dto.ModuleBootstrapDiscovery;
 import org.folio.am.service.ModuleBootstrapService;
 import org.folio.test.TestUtils;
 import org.folio.test.types.UnitTest;

--- a/src/test/java/org/folio/am/it/KongRegistrationIT.java
+++ b/src/test/java/org/folio/am/it/KongRegistrationIT.java
@@ -33,6 +33,6 @@ class KongRegistrationIT extends BaseIntegrationTest {
     });
 
     var routes = kongAdminClient.getRoutesByTag(moduleName, null);
-    assertThat(routes.getData()).hasSize(18);
+    assertThat(routes.getData()).hasSize(20);
   }
 }

--- a/src/test/java/org/folio/am/it/ModuleBootstrapIT.java
+++ b/src/test/java/org/folio/am/it/ModuleBootstrapIT.java
@@ -16,6 +16,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.util.List;
 import org.folio.am.domain.dto.ApplicationDescriptor;
+import org.folio.am.domain.dto.EgressBootstrap;
+import org.folio.am.domain.dto.EgressBootstrapRequest;
 import org.folio.am.domain.dto.Module;
 import org.folio.am.domain.dto.ModuleBootstrap;
 import org.folio.am.domain.dto.ModuleBootstrapDiscovery;
@@ -139,6 +141,97 @@ class ModuleBootstrapIT extends BaseIntegrationTest {
         .header(TOKEN, generateAccessToken(keycloakProperties)))
       .andExpect(status().isOk())
       .andExpect(content().json(asJsonString(expectedBootstrapResponse), STRICT));
+  }
+
+  @Test
+  void ingressBootstrap_positive() throws Exception {
+    // Consumer both provides its own interface and requires another; ingress must return only its own routes.
+    var consumerApp = new ApplicationDescriptor()
+      .name("test-app").version("1.0.0")
+      .modules(List.of(new Module().name("consumer").version("1.0.0")))
+      .moduleDescriptors(List.of(new ModuleDescriptor()
+        .id("consumer-1.0.0")
+        .requires(List.of(new InterfaceReference().id("dashboard").version("2.0")))
+        .provides(List.of(new InterfaceDescriptor().id("consumer-api").version("1.0").interfaceType("multiple")))));
+    postApplication(consumerApp);
+
+    var expected = new ModuleBootstrap()
+      .module(new ModuleBootstrapDiscovery()
+        .moduleId("consumer-1.0.0")
+        .applicationId("test-app-1.0.0")
+        .systemUserRequired(false)
+        .interfaces(List.of(new ModuleBootstrapInterface().id("consumer-api").version("1.0").interfaceType("multiple"))))
+      .requiredModules(List.of());
+
+    mockMvc.perform(get("/modules/{id}/bootstrap", "consumer-1.0.0")
+        .header(TOKEN, generateAccessToken(keycloakProperties)))
+      .andExpect(status().isOk())
+      .andExpect(content().json(asJsonString(expected), STRICT));
+  }
+
+  @Test
+  void egressBootstrap_positive_scoped() throws Exception {
+    var providerApp = new ApplicationDescriptor()
+      .name("provider-app").version("1.0.0")
+      .modules(List.of(new Module().name("mod-provider").version("1.0.0")))
+      .moduleDescriptors(List.of(new ModuleDescriptor()
+        .id("mod-provider-1.0.0")
+        .provides(List.of(new InterfaceDescriptor().id("dashboard").version("2.0").interfaceType("multiple")))));
+    postApplication(providerApp);
+
+    mockMvc.perform(post("/modules/{id}/discovery", "mod-provider-1.0.0")
+        .header(TOKEN, generateAccessToken(keycloakProperties))
+        .contentType(APPLICATION_JSON)
+        .content(asJsonString(moduleDiscovery("mod-provider", "1.0.0", "http://mod-provider:8081"))))
+      .andExpect(status().isCreated());
+
+    var consumerApp = new ApplicationDescriptor()
+      .name("test-app").version("1.0.0")
+      .modules(List.of(new Module().name("consumer").version("1.0.0")))
+      .moduleDescriptors(List.of(new ModuleDescriptor()
+        .id("consumer-1.0.0")
+        .requires(List.of(new InterfaceReference().id("dashboard").version("2.0")))));
+    postApplication(consumerApp);
+
+    // In full scope: provider is resolved.
+    var expectedInScope = new EgressBootstrap().requiredModules(List.of(new ModuleBootstrapDiscovery()
+      .moduleId("mod-provider-1.0.0")
+      .applicationId("provider-app-1.0.0")
+      .location("http://mod-provider:8081")
+      .systemUserRequired(false)
+      .interfaces(List.of(new ModuleBootstrapInterface().id("dashboard").version("2.0").interfaceType("multiple")))));
+
+    mockMvc.perform(post("/modules/{id}/bootstrap", "consumer-1.0.0")
+        .header(TOKEN, generateAccessToken(keycloakProperties))
+        .contentType(APPLICATION_JSON)
+        .content(asJsonString(new EgressBootstrapRequest()
+          .applicationIds(List.of("provider-app-1.0.0", "test-app-1.0.0")))))
+      .andExpect(status().isOk())
+      .andExpect(content().json(asJsonString(expectedInScope), STRICT));
+
+    // Provider out of scope: empty requiredModules (consumer itself still in scope).
+    var expectedOutOfScope = new EgressBootstrap().requiredModules(List.of());
+    mockMvc.perform(post("/modules/{id}/bootstrap", "consumer-1.0.0")
+        .header(TOKEN, generateAccessToken(keycloakProperties))
+        .contentType(APPLICATION_JSON)
+        .content(asJsonString(new EgressBootstrapRequest().applicationIds(List.of("test-app-1.0.0")))))
+      .andExpect(status().isOk())
+      .andExpect(content().json(asJsonString(expectedOutOfScope), STRICT));
+  }
+
+  @Test
+  void egressBootstrap_negative_moduleNotInScope() throws Exception {
+    var consumerApp = new ApplicationDescriptor()
+      .name("test-app").version("1.0.0")
+      .modules(List.of(new Module().name("consumer").version("1.0.0")))
+      .moduleDescriptors(List.of(new ModuleDescriptor().id("consumer-1.0.0")));
+    postApplication(consumerApp);
+
+    mockMvc.perform(post("/modules/{id}/bootstrap", "consumer-1.0.0")
+        .header(TOKEN, generateAccessToken(keycloakProperties))
+        .contentType(APPLICATION_JSON)
+        .content(asJsonString(new EgressBootstrapRequest().applicationIds(List.of("other-app-1.0.0")))))
+      .andExpect(status().isNotFound());
   }
 
   private void postApplication(ApplicationDescriptor applicationDescriptor) throws Exception {

--- a/src/test/java/org/folio/am/it/ModuleBootstrapIT.java
+++ b/src/test/java/org/folio/am/it/ModuleBootstrapIT.java
@@ -160,7 +160,8 @@ class ModuleBootstrapIT extends BaseIntegrationTest {
         .moduleId("consumer-1.0.0")
         .applicationId("test-app-1.0.0")
         .systemUserRequired(false)
-        .interfaces(List.of(new ModuleBootstrapInterface().id("consumer-api").version("1.0").interfaceType("multiple"))))
+        .interfaces(List.of(
+          new ModuleBootstrapInterface().id("consumer-api").version("1.0").interfaceType("multiple"))))
       .requiredModules(List.of());
 
     mockMvc.perform(get("/modules/{id}/bootstrap", "consumer-1.0.0")

--- a/src/test/java/org/folio/am/repository/ModuleBootstrapRepositoryIT.java
+++ b/src/test/java/org/folio/am/repository/ModuleBootstrapRepositoryIT.java
@@ -105,6 +105,23 @@ class ModuleBootstrapRepositoryIT extends BaseRepositoryTest {
       .anyMatch(matchView(MODULE_FOO_ID, APP_1_0_0_ID, MODULE_FOO_DISCOVERY_URL));
   }
 
+  @Test
+  void findAllRequiredByModuleId_returnsProviderOnceWhenItProvidesMultipleRequiredInterfaces() {
+    // test-module-bar provides both test-bar-interface and test-bar-interface-2, and test-module-foo requires both;
+    // the provider must appear once (the IN subquery is a semi-join), not be fanned out now that DISTINCT is gone.
+    var result = repository.findAllRequiredByModuleId(MODULE_FOO_ID);
+
+    assertThat(result).hasSize(3);
+    assertThat(result).filteredOn(view -> view.getId().equals(MODULE_BAR_ID)).hasSize(1);
+    assertNoDuplicateRows(result);
+  }
+
+  private static void assertNoDuplicateRows(List<ModuleBootstrapView> views) {
+    assertThat(views)
+      .extracting(view -> view.getId() + "@" + view.getApplicationId())
+      .doesNotHaveDuplicates();
+  }
+
   private Predicate<ModuleBootstrapView> matchView(String moduleId, String appId, String location) {
     return view ->
       view.getId().equals(moduleId)

--- a/src/test/java/org/folio/am/repository/ModuleBootstrapRepositoryIT.java
+++ b/src/test/java/org/folio/am/repository/ModuleBootstrapRepositoryIT.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_METHOD;
 
+import java.util.List;
 import java.util.function.Predicate;
 import org.folio.am.domain.entity.ModuleBootstrapView;
 import org.folio.am.support.base.BaseRepositoryTest;
@@ -65,6 +66,43 @@ class ModuleBootstrapRepositoryIT extends BaseRepositoryTest {
     assertThat(result)
       .hasSize(1)
       .anyMatch(matchView(MODULE_BAR_ID, APP_2_0_0_ID, MODULE_BAR_DISCOVERY_URL));
+  }
+
+  @Test
+  void findAllRequiredByModuleIdAndApplicationIdsIn_returnsOnlyInScopeModules() {
+    var result = repository.findAllRequiredByModuleIdAndApplicationIdsIn(MODULE_FOO_ID, List.of(APP_1_0_0_ID));
+    assertThat(result)
+      .hasSize(1)
+      .anyMatch(matchView(MODULE_FOO_ID, APP_1_0_0_ID, MODULE_FOO_DISCOVERY_URL));
+  }
+
+  @Test
+  void findAllRequiredByModuleIdAndApplicationIdsIn_returnsAllWhenAllAppsInScope() {
+    var result = repository.findAllRequiredByModuleIdAndApplicationIdsIn(
+      MODULE_FOO_ID, List.of(APP_1_0_0_ID, APP_2_0_0_ID));
+    assertThat(result)
+      .hasSize(3)
+      .anyMatch(matchView(MODULE_FOO_ID, APP_1_0_0_ID, MODULE_FOO_DISCOVERY_URL))
+      .anyMatch(matchView(MODULE_BAR_ID, APP_2_0_0_ID, MODULE_BAR_DISCOVERY_URL))
+      .anyMatch(matchView(MODULE_BAZ_ID, APP_2_0_0_ID, MODULE_BAZ_DISCOVERY_URL));
+  }
+
+  @Test
+  void findAllRequiredByModuleIdAndApplicationIdsIn_excludesSelfWhenSelfNotInScope() {
+    var result = repository.findAllRequiredByModuleIdAndApplicationIdsIn(MODULE_FOO_ID, List.of(APP_2_0_0_ID));
+    assertThat(result)
+      .hasSize(2)
+      .noneMatch(view -> view.getId().equals(MODULE_FOO_ID))
+      .anyMatch(matchView(MODULE_BAR_ID, APP_2_0_0_ID, MODULE_BAR_DISCOVERY_URL))
+      .anyMatch(matchView(MODULE_BAZ_ID, APP_2_0_0_ID, MODULE_BAZ_DISCOVERY_URL));
+  }
+
+  @Test
+  void findViewsById_returnsSelfRow() {
+    var result = repository.findViewsById(MODULE_FOO_ID);
+    assertThat(result)
+      .hasSize(1)
+      .anyMatch(matchView(MODULE_FOO_ID, APP_1_0_0_ID, MODULE_FOO_DISCOVERY_URL));
   }
 
   private Predicate<ModuleBootstrapView> matchView(String moduleId, String appId, String location) {

--- a/src/test/java/org/folio/am/service/ModuleBootstrapServiceTest.java
+++ b/src/test/java/org/folio/am/service/ModuleBootstrapServiceTest.java
@@ -100,4 +100,50 @@ class ModuleBootstrapServiceTest {
     assertThatThrownBy(() -> service.getById(MODULE_FOO_ID)).isInstanceOf(EntityNotFoundException.class)
       .hasMessage("Module not found by id: " + MODULE_FOO_ID);
   }
+
+  @Test
+  void getIngressBootstrap_positive() {
+    var fooView = moduleBootstrapView(MODULE_FOO_ID, MODULE_FOO_INTERFACE_ID);
+    when(repository.findViewsById(MODULE_FOO_ID)).thenReturn(new ArrayList<>(List.of(fooView)));
+
+    var actual = service.getIngressBootstrap(MODULE_FOO_ID);
+
+    assertThat(actual.getModule()).isEqualTo(moduleBootstrapDiscovery(MODULE_FOO_ID, MODULE_FOO_INTERFACE_ID));
+    assertThat(actual.getRequiredModules()).isEmpty();
+  }
+
+  @Test
+  void getIngressBootstrap_negative_notFound() {
+    when(repository.findViewsById(MODULE_FOO_ID)).thenReturn(Collections.emptyList());
+
+    assertThatThrownBy(() -> service.getIngressBootstrap(MODULE_FOO_ID))
+      .isInstanceOf(EntityNotFoundException.class)
+      .hasMessage("Module not found by id: " + MODULE_FOO_ID);
+  }
+
+  @Test
+  void getEgressBootstrap_positive() {
+    var fooView = moduleBootstrapView(MODULE_FOO_ID, MODULE_FOO_INTERFACE_ID);
+    fooView.getDescriptor().addRequiresItem(new InterfaceReference().id(MODULE_BAR_INTERFACE_ID));
+    var barView = moduleBootstrapView(MODULE_BAR_ID, MODULE_BAR_INTERFACE_ID, "not-required-interface");
+    var scope = List.of("test-app-1.0.0");
+    when(repository.findAllRequiredByModuleIdAndApplicationIdsIn(MODULE_FOO_ID, scope))
+      .thenReturn(new ArrayList<>(asList(fooView, barView)));
+
+    var actual = service.getEgressBootstrap(MODULE_FOO_ID, scope);
+
+    assertThat(actual.getRequiredModules())
+      .containsExactly(moduleBootstrapDiscovery(MODULE_BAR_ID, MODULE_BAR_INTERFACE_ID));
+  }
+
+  @Test
+  void getEgressBootstrap_negative_moduleNotInScope() {
+    var scope = List.of("other-app-1.0.0");
+    when(repository.findAllRequiredByModuleIdAndApplicationIdsIn(MODULE_FOO_ID, scope))
+      .thenReturn(new ArrayList<>());
+
+    assertThatThrownBy(() -> service.getEgressBootstrap(MODULE_FOO_ID, scope))
+      .isInstanceOf(EntityNotFoundException.class)
+      .hasMessage("Module not found by id: " + MODULE_FOO_ID);
+  }
 }

--- a/src/test/resources/sql/module-interface-references.sql
+++ b/src/test/resources/sql/module-interface-references.sql
@@ -2,4 +2,9 @@ insert into module_interface_reference(module_id, id, version, type) VALUES
   ('test-module-foo-1.0.0', 'test-bar-interface', '1.0', 'REQUIRES'),
   ('test-module-bar-1.0.0', 'test-bar-interface', '1.0', 'PROVIDES'),
   ('test-module-foo-1.0.0', 'test-baz-interface', '1.0', 'REQUIRES'),
-  ('test-module-baz-1.0.0', 'test-baz-interface', '1.0', 'PROVIDES');
+  ('test-module-baz-1.0.0', 'test-baz-interface', '1.0', 'PROVIDES'),
+  -- test-module-bar provides a SECOND interface that test-module-foo also requires. With the bootstrap queries no
+  -- longer using DISTINCT, this guards that the provider row is still returned once (the IN subquery is a semi-join
+  -- and must not fan bar out to two rows).
+  ('test-module-foo-1.0.0', 'test-bar-interface-2', '1.0', 'REQUIRES'),
+  ('test-module-bar-1.0.0', 'test-bar-interface-2', '1.0', 'PROVIDES');


### PR DESCRIPTION
### **Purpose**

In a multi-version environment a module sidecar must build its ingress/egress route tables for the specific application versions entitled to a tenant; resolving egress globally can select the wrong module version. This PR adds the **mgr-applications** side of that: application-scoped egress resolution plus an ingress-only bootstrap endpoint, so a sidecar can request exactly the routes for a given application scope.

US: [EUREKA-899](https://folio-org.atlassian.net/browse/EUREKA-899)

### **Approach**

Two new endpoints are layered on top of the existing global `GET /modules/{id}` bootstrap, which is left unchanged. `GET /modules/{id}/bootstrap` returns only the module's own routes (ingress); `POST /modules/{id}/bootstrap` resolves the module's required/optional providers but restricted to a supplied list of application IDs (egress). Scoping is applied in SQL over the existing `v_module_bootstrap` view — there is no tenant context and no DB/view change.

- Added `GET /modules/{id}/bootstrap` (`getModuleIngressBootstrap`) returning a `moduleBootstrap` with the module's own discovery and an empty `requiredModules`.
- Added `POST /modules/{id}/bootstrap` (`getModuleEgressBootstrap`) accepting `egressBootstrapRequest` and returning `egressBootstrap`; required-module resolution is restricted to providers whose owning application is in `applicationIds`. Returns `404` when the module is not in the supplied scope and `400` when `applicationIds` is empty.
- Introduced the `egressBootstrapRequest` (`applicationIds`, at least one id) and `egressBootstrap` (`requiredModules` only) schemas and registered them in `am.yaml`.
- Added `ModuleBootstrapRepository.findAllRequiredByModuleIdAndApplicationIdsIn`, the existing dependency-resolution query constrained by `view.applicationId IN :applicationIds`, plus `findViewsById` for the ingress self-row lookup.
- Added `ModuleBootstrapService.getIngressBootstrap` and `getEgressBootstrap`, and refactored `getById` to share dependency resolution through a private `resolveRequiredModules` helper.
- Implemented the two generated controller methods in `ModuleBootstrapController`, delegating to the service.
- Registered the two `/modules/{id}/bootstrap` handlers in `ModuleDescriptor.json`, added the `mgr-applications.module-bootstraps.item.post` permission (granted in `mgr-applications.readonly` and `mgr-applications.all`), and bumped the `module-bootstraps` interface version from `1.2` to `1.3`.
- Removed the redundant `DISTINCT` from `findAllRequiredByModuleId` and `findAllRequiredByModuleIdAndApplicationIdsIn`; the `(module, application)` view grain is unique by the `application_module` composite key and the nested `IN` subqueries are semi-joins, so duplicate rows are not possible.

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [x] API/schema changes
  - [x] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
