### PR TITLE
APPPOCTOOL-37: Switch Kong integration test container to folioci/folio-kong image

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ## Version `v4.1.0` (IN PROGRESS)
 * Allow interface to be both provided and require / optional in the same module descriptor (MGRAPPS-99)
 * Upgrade dependencies for Kafka 4.2 compatibility in mgr-applications (MGRAPPS-110)
+* Switch Kong integration test container to folioci/folio-kong image (APPPOCTOOL-37)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Version 2.0. See the file "[LICENSE](LICENSE)" for more information.
   * [Event structure](#event-structure)
 * [Manager Tenant Entitlements Integration](#manager-tenant-entitlements-integration)
 * [Folio Application Registry mode](#folio-application-registry-mode)
+* [Integration Testing](#integration-testing)
 
 ## Introduction
 
@@ -346,6 +347,18 @@ the integrations with Kafka, Kong, Okapi, mgr-tenant-entitlements is disabled.
 To enable this mode set `FAR_MODE` env variable to `true` and make sure to leave other integration variables unset or
 set to `false`.
 
+
+## Integration Testing
+
+Integration tests use Testcontainers for PostgreSQL and Kong. The following environment variables
+let you redirect containers to a private registry or adjust startup behaviour without changing
+source code.
+
+| Environment variable                     | Default                         | Description                          |
+|:-----------------------------------------|:--------------------------------|:-------------------------------------|
+| `TESTCONTAINERS_POSTGRES_IMAGE`          | `postgres:16-alpine`            | PostgreSQL container image           |
+| `TESTCONTAINERS_KONG_IMAGE`              | `folioci/folio-kong:latest`     | Kong container image                 |
+| `TESTCONTAINERS_KONG_READINESS_TIMEOUT`  | `120`                           | Seconds to wait for Kong startup     |
 
 ## AI Documentation
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/folio-org/mgr-applications)

--- a/src/test/java/org/folio/am/support/extensions/impl/KongGatewayExtension.java
+++ b/src/test/java/org/folio/am/support/extensions/impl/KongGatewayExtension.java
@@ -1,8 +1,9 @@
 package org.folio.am.support.extensions.impl;
 
-import static java.time.Duration.ofSeconds;
 import static org.folio.am.support.extensions.impl.PostgresContainerExtension.POSTGRES_NETWORK_ALIAS;
+import static org.folio.test.extensions.impl.DockerImageRegistry.getKongImageName;
 
+import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
@@ -11,27 +12,30 @@ import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
-import org.testcontainers.containers.startupcheck.OneShotStartupCheckStrategy;
+import org.testcontainers.containers.wait.strategy.Wait;
 
 @Slf4j
 public class KongGatewayExtension implements BeforeAllCallback, AfterAllCallback {
 
   public static final String KONG_GATEWAY_URL_PROPERTY = "kong.gateway.url";
-  public static final String KONG_DOCKER_IMAGE = "kong:3.7.1-ubuntu";
   public static final String KONG_URL_PROPERTY = "kong.url";
 
-  @SuppressWarnings("resource")
-  private static final GenericContainer<?> CONTAINER = new GenericContainer<>(KONG_DOCKER_IMAGE)
-    .withEnv(kongEnvironment())
-    .withNetwork(Network.SHARED)
-    .withExposedPorts(8000, 8001)
-    .withAccessToHost(true);
+  private static final String ENV_KONG_READINESS_TIMEOUT = "TESTCONTAINERS_KONG_READINESS_TIMEOUT";
+  private static final long DEFAULT_CONTAINER_READINESS_TIMEOUT = 120;
+
+  private static final long CONTAINER_READINESS_TIMEOUT;
+  private static final GenericContainer<?> CONTAINER;
+
+  static {
+    var env = System.getenv();
+    CONTAINER_READINESS_TIMEOUT = Long.parseLong(
+      env.getOrDefault(ENV_KONG_READINESS_TIMEOUT, String.valueOf(DEFAULT_CONTAINER_READINESS_TIMEOUT)));
+    CONTAINER = kongContainer(getKongImageName());
+  }
 
   @Override
   public void beforeAll(ExtensionContext extensionContext) {
     if (!CONTAINER.isRunning()) {
-      runMigrationWithContainer("kong migrations bootstrap");
-      runMigrationWithContainer("kong migrations up && kong migrations finish");
       CONTAINER.start();
     }
 
@@ -49,23 +53,20 @@ public class KongGatewayExtension implements BeforeAllCallback, AfterAllCallback
     return String.format("http://%s:%s", CONTAINER.getHost(), CONTAINER.getMappedPort(port));
   }
 
-  private static void runMigrationWithContainer(String command) {
-    try (var bootstrapMigrations = migrationContainer(command)) {
-      bootstrapMigrations.start();
-    } catch (Exception e) {
-      throw new RuntimeException("Failed to run kong migrations", e);
-    }
-  }
-
-  private static GenericContainer<?> migrationContainer(String command) {
-    return new GenericContainer<>(KONG_DOCKER_IMAGE)
-      .withEnv(kongMigrationEnvironment())
-      .withCommand(command)
+  @SuppressWarnings("resource")
+  private static GenericContainer<?> kongContainer(String imageName) {
+    return new GenericContainer<>(imageName)
+      .withEnv(kongEnvironment())
       .withNetwork(Network.SHARED)
-      .withStartupCheckStrategy(new OneShotStartupCheckStrategy().withTimeout(ofSeconds(5)));
+      .withExposedPorts(8000, 8001)
+      .withAccessToHost(true)
+      .waitingFor(Wait.forHttp("/status")
+        .forPort(8001)
+        .forStatusCode(200)
+        .withStartupTimeout(Duration.ofSeconds(CONTAINER_READINESS_TIMEOUT)));
   }
 
-  private static Map<String, String> kongMigrationEnvironment() {
+  private static Map<String, String> kongEnvironment() {
     var environment = new LinkedHashMap<String, String>();
 
     environment.put("KONG_DATABASE", "postgres");
@@ -74,16 +75,6 @@ public class KongGatewayExtension implements BeforeAllCallback, AfterAllCallback
     environment.put("KONG_PG_PASSWORD", "kong123");
     environment.put("KONG_PG_PORT", "5432");
     environment.put("KONG_PG_HOST", POSTGRES_NETWORK_ALIAS);
-    environment.put("KONG_ROUTER_FLAVOR", "expressions");
-
-    return environment;
-  }
-
-  private static Map<String, String> kongEnvironment() {
-    var environment = new LinkedHashMap<>(kongMigrationEnvironment());
-
-    environment.put("KONG_PROXY_ACCESS_LOG", "/dev/stdout");
-    environment.put("KONG_ADMIN_ACCESS_LOG", "/dev/stdout");
     environment.put("KONG_PROXY_ERROR_LOG", "/dev/stderr");
     environment.put("KONG_ADMIN_ERROR_LOG", "/dev/stderr");
     environment.put("KONG_PROXY_LISTEN", "0.0.0.0:8000");

--- a/src/test/java/org/folio/am/support/extensions/impl/PostgresContainerExtension.java
+++ b/src/test/java/org/folio/am/support/extensions/impl/PostgresContainerExtension.java
@@ -1,6 +1,7 @@
 package org.folio.am.support.extensions.impl;
 
 import static java.lang.String.valueOf;
+import static org.folio.test.extensions.impl.DockerImageRegistry.getPostgresImageName;
 
 import java.util.UUID;
 import org.junit.jupiter.api.extension.AfterAllCallback;
@@ -16,7 +17,7 @@ public class PostgresContainerExtension implements BeforeAllCallback, AfterAllCa
   private static final String DB_PORT_PROPERTY = "DB_PORT";
 
   @SuppressWarnings("resource")
-  private static final PostgreSQLContainer<?> CONTAINER = new PostgreSQLContainer<>("postgres:16-alpine")
+  private static final PostgreSQLContainer<?> CONTAINER = new PostgreSQLContainer<>(getPostgresImageName())
     .withDatabaseName("postgres")
     .withEnv("PG_USER", "postgres")
     .withUsername("postgres")


### PR DESCRIPTION
### Purpose

The vanilla `kong:3.7.1-ubuntu` image requires the application to spin up ephemeral migration containers before Kong starts, and several Kong configuration env vars must be set explicitly. Switching to `folioci/folio-kong:latest` eliminates that overhead: migrations run automatically inside the image's entrypoint, and router flavour, access log format, and the `auth-headers-manager` plugin are baked in.

US: [APPPOCTOOL-37](https://folio-org.atlassian.net/browse/APPPOCTOOL-37)

### Approach

Switched the Kong test container to the FOLIO-specific `folioci/folio-kong` image, which runs database migrations automatically and bakes in router configuration and access log settings. Both the Kong and Postgres images are now sourced from a central registry, making them overridable via environment variables.

- Switched the Kong container to `folioci/folio-kong:latest` (was `kong:3.7.1-ubuntu`), overridable via the `TESTCONTAINERS_KONG_IMAGE` environment variable.
- Removed the two migration containers that previously ran before Kong started — the folio-kong image handles this internally.
- Added an HTTP health check on the Kong admin status endpoint with a configurable startup timeout (120 s by default, overridable via `TESTCONTAINERS_KONG_READINESS_TIMEOUT`).
- Switched the Postgres container image to the central registry, making it overridable via `TESTCONTAINERS_POSTGRES_IMAGE`.

### Dependencies

> Requires [folio-org/applications-poc-tools#339](https://github.com/folio-org/applications-poc-tools/pull/339) to be merged and the updated `folio-backend-testing` artifact to be published before this PR can be merged.

### Pre-Review Checklist

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Dependent module build verification** — Ran manually when library changes impact downstream modules.
  > Actions → Verify Dependent Modules → Run workflow → select branch → Run.
- [ ] **Breaking Changes (if any)** — Handled if changes affect integration with other services.
- [x] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.