### PR TITLE
EUREKA-887: Generalize references to Kong -> API Gateway

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,14 +26,14 @@ Layers: Controllers (implement OpenAPI-generated interfaces) → Services → Re
 **Repositories** extend `JpaCqlRepository` for CQL filtering (e.g. `name=="app*"`) via `cql2pgjson`; use `findByQuery()`.
 
 **Integrations**:
-- Kong (via `folio-integration-kong`): self-registers the module's service + routes in Kong at startup (`KongModuleRegistrar`, `MODULE_URL`, `REGISTER_MODULE_IN_KONG`). Toggle `KONG_INTEGRATION_ENABLED`.
+- Kong (via `folio-integration-kong`): self-registers the module's service + routes in Kong at startup (`ApiGatewayModuleRegistrar`, `MODULE_URL`, `APIGW_REGISTER_MODULE`). Toggle `APIGW_ENABLED`. Legacy `KONG_INTEGRATION_ENABLED` / `REGISTER_MODULE_IN_KONG` still work but are deprecated.
 - Kafka (`integration.kafka`): `DiscoveryPublisher` publishes `${ENV}.discovery` events.
 - Keycloak (via `folio-security`): resource-server/client/role/policy import; JWT validation. Toggle `KC_INTEGRATION_ENABLED`.
 - mgr-tenant-entitlements (`integration.mte`): blocks deletion of entitled applications.
 
 **Events** via `ApplicationEventPublisher`: `ApplicationDiscoveryListener` (discovery create/update/delete) drives Kafka side effects. Reliable publishing via transactional outbox (`integration.messaging`).
 
-**FAR mode** (`FAR_MODE=true`): descriptor CRUD only; disables Kafka/Keycloak/mte. Kong self-registration is not disabled by FAR mode — set `KONG_INTEGRATION_ENABLED=false` explicitly.
+**FAR mode** (`FAR_MODE=true`): descriptor CRUD only; disables Kafka/Keycloak/mte. Kong self-registration is not disabled by FAR mode — set `APIGW_ENABLED=false` explicitly.
 
 **Validation** (`VALIDATION_MODE`): NONE / BASIC / ON_CREATE (full dependency checks).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@
 * Application-scoped sidecar bootstrap: ingress and egress module-bootstrap endpoints (EUREKA-899)
 * Switch Kong integration test container to folioci/folio-kong image (APPPOCTOOL-37)
 * Remove Kong gateway route management (discovery-driven service/route synchronization and tenant checks via entitlement events); module self-registration in Kong remains (MGRAPPS-108)
+* Generalize API Gateway configuration to `application.apigw.*` properties and `APIGW_*` environment variables; legacy
+  `application.kong.*` properties and `KONG_*` variables keep working, are reported with a `WARN` at startup and are
+  planned for removal in the `Vetch` release (EUREKA-887)
 * **Breaking:** Remove "Okapi integration" mode. `OKAPI_INTEGRATION_ENABLED`, `OKAPI_URL` and
   `MOD_AUTHTOKEN_URL` are no longer supported, module/discovery descriptors are no longer pushed to
   an Okapi gateway, and mod-authtoken security mode is no longer reachable. The `okapi.*`

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Version 2.0. See the file "[LICENSE](LICENSE)" for more information.
 * [Compiling](#compiling)
 * [Running It](#running-it)
 * [Environment Variables](#environment-variables)
+  * [Deprecated environment variables](#deprecated-environment-variables)
   * [SSL Configuration environment variables](#ssl-configuration-environment-variables)
   * [Secure storage environment variables](#secure-storage-environment-variables)
     * [AWS-SSM](#aws-ssm)
@@ -20,8 +21,8 @@ Version 2.0. See the file "[LICENSE](LICENSE)" for more information.
   * [Import Keycloak data on startup](#import-keycloak-data-on-startup)
   * [Keycloak Security](#keycloak-security)
   * [Keycloak specific environment variables](#keycloak-specific-environment-variables)
-* [Kong Gateway Integration](#kong-gateway-integration)
-  * [Kong Self-Registration](#kong-self-registration)
+* [API Gateway Integration](#api-gateway-integration)
+  * [Gateway Self-Registration](#gateway-self-registration)
 * [Kafka Integration](#kafka-integration)
   * [Events upon discovery changes](#events-upon-discovery-changes)
   * [Naming convention](#naming-convention)
@@ -91,19 +92,19 @@ docker run \
 | DB_USERNAME                              | postgres                     |  false   | Postgres username                                                                                                                                                                                          |
 | DB_PASSWORD                              | postgres                     |  false   | Postgres username password                                                                                                                                                                                 |
 | DB_DATABASE                              | okapi_modules                |  false   | Postgres database name                                                                                                                                                                                     |
-| MODULE_URL                               | http://mgr-applications:8081 |  false   | Module URL (module cannot define url for Kong registration by itself, because it can be under Load Balancer, so this value must be provided manually)                                                      |
+| MODULE_URL                               | http://mgr-applications:8081 |  false   | Module URL (module cannot define url for gateway registration by itself, because it can be under Load Balancer, so this value must be provided manually)                                                   |
 | tenant.url                               | -                            |   true   | Tenant URL used to perform HTTP requests by `TenantManagerClient`.                                                                                                                                         |
-| kong.url                                 | -                            |   true   | Kong Admin URL used to perform HTTP requests for self-registration, required.                                                                                                                              |
-| KONG_ADMIN_URL                           | -                            |  false   | Alias for `kong.url`.                                                                                                                                                                                      |
-| KONG_INTEGRATION_ENABLED                 | true                         |  false   | Defines if kong integration is enabled or disabled.<br/>If it set to `false` - it will exclude all kong-related beans from spring context.                                                                 |
-| KONG_CONNECT_TIMEOUT                     | -                            |  false   | Defines the timeout in milliseconds for establishing a connection from Kong to upstream service. If the value is not provided then Kong defaults are applied.                                              |
-| KONG_READ_TIMEOUT                        | -                            |  false   | Defines the timeout in milliseconds between two successive read operations for transmitting a request from Kong to the upstream service. If the value is not provided then Kong defaults are applied.      |
-| KONG_WRITE_TIMEOUT                       | -                            |  false   | Defines the timeout in milliseconds between two successive write operations for transmitting a request from Kong to the upstream service. If the value is not provided then Kong defaults are applied.     |
-| KONG_RETRIES                             | -                            |  false   | Defines the number of retries to execute upon failure to proxy. If the value is not provided then Kong defaults are applied.                                                                               |
-| KONG_TLS_ENABLED                         | false                        |  false   | Allows to enable/disable TLS connection to Kong.                                                                                                                                                           |
-| KONG_TLS_TRUSTSTORE_PATH                 | -                            |  false   | Truststore file path for TLS connection to Kong.                                                                                                                                                           |
-| KONG_TLS_TRUSTSTORE_PASSWORD             | -                            |  false   | Truststore password for TLS connection to Kong.                                                                                                                                                            |
-| KONG_TLS_TRUSTSTORE_TYPE                 | -                            |  false   | Truststore type for TLS connection to Kong.                                                                                                                                                                |
+| APIGW_URL                                | -                            |   true   | API Gateway Admin URL used to perform HTTP requests for self-registration, required.                                                                                                                       |
+| kong.url                                 | -                            |  false   | Lowest-precedence system-property fallback for `APIGW_URL`, used by the integration test infrastructure.                                                                                                   |
+| APIGW_ENABLED                            | true                         |  false   | Defines if API Gateway integration is enabled or disabled.<br/>If it set to `false` - it will exclude all gateway-related beans from spring context.                                                       |
+| APIGW_CONNECT_TIMEOUT                    | -                            |  false   | Defines the timeout in milliseconds for establishing a connection from the gateway to upstream service. If the value is not provided then gateway defaults are applied.                                    |
+| APIGW_READ_TIMEOUT                       | -                            |  false   | Defines the timeout in milliseconds between two successive read operations for transmitting a request from the gateway to the upstream service. If the value is not provided then gateway defaults are applied. |
+| APIGW_WRITE_TIMEOUT                      | -                            |  false   | Defines the timeout in milliseconds between two successive write operations for transmitting a request from the gateway to the upstream service. If the value is not provided then gateway defaults are applied. |
+| APIGW_RETRIES                            | -                            |  false   | Defines the number of retries to execute upon failure to proxy. If the value is not provided then gateway defaults are applied.                                                                            |
+| APIGW_TLS_ENABLED                        | false                        |  false   | Allows to enable/disable TLS connection to the API Gateway.                                                                                                                                                |
+| APIGW_TLS_TRUSTSTORE_PATH                | -                            |  false   | Truststore file path for TLS connection to the API Gateway.                                                                                                                                                |
+| APIGW_TLS_TRUSTSTORE_PASSWORD            | -                            |  false   | Truststore password for TLS connection to the API Gateway.                                                                                                                                                 |
+| APIGW_TLS_TRUSTSTORE_TYPE                | -                            |  false   | Truststore type for TLS connection to the API Gateway.                                                                                                                                                     |
 | ENV                                      | folio                        |  false   | The logical name of the deployment (kafka topic prefix), must be unique across all environments using the same shared Kafka/Elasticsearch clusters, `a-z (any case)`, `0-9`, `-`, `_` symbols only allowed |
 | KAFKA_HOST                               | kafka                        |  false   | Kafka broker hostname                                                                                                                                                                                       |
 | KAFKA_PORT                               | 9092                         |  false   | Kafka broker port                                                                                                                                                                                           |
@@ -120,13 +121,36 @@ docker run \
 | TE_TLS_TRUSTSTORE_PASSWORD               | -                            |  false   | Truststore password for TLS connection to mgr-tenant-entitlements module.                                                                                                                                  |
 | TE_TLS_TRUSTSTORE_TYPE                   | -                            |  false   | Truststore file type for TLS connection to mgr-tenant-entitlements module.                                                                                                                                 |
 | SECURITY_ENABLED                         | true                         |  false   | Allows to enable/disable security. If true and KC_INTEGRATION_ENABLED is also true - the Keycloak will be used as a security provider.                                                                     |
-| FAR_MODE                                 | false                        |  false   | Allows to enable Folio Application Registry mode, if FAR mode is enabled, kong integration must disabled using environment variable `KONG_INTEGRATION_ENABLED`.                                            |
+| FAR_MODE                                 | false                        |  false   | Allows to enable Folio Application Registry mode, if FAR mode is enabled, API Gateway integration must be disabled using environment variable `APIGW_ENABLED`.                                             |
 | SECURE\_STORE\_ENV                       | folio                        |  false   | First segment of the secure store key, for example `prod` or `test`. Defaults to `folio`. In Ramsons and Sunflower defaults to ENV with fall-back `folio`.                                                 |
 | SECRET_STORE_TYPE                        | -                            |   true   | Secure storage type. Supported values: `EPHEMERAL`, `AWS_SSM`, `VAULT`, `FSSP`                                                                                                                             |
 | VALIDATION_MODE                          | basic                        |  false   | Validation mode applied during Application Descriptors checking (see POST `/applications/validate` endpoint). Possible values: `none`, `basic`, `onCreate`                                                 |
 | MAX_HTTP_REQUEST_HEADER_SIZE             | 200KB                        |   true   | Maximum size of the HTTP request header.                                                                                                                                                                   |
-| REGISTER_MODULE_IN_KONG                  | true                         |  false   | Defines if module must be registered in Kong (it will create for itself service and list of routes from module descriptor)                                                                                 |
+| APIGW_REGISTER_MODULE                    | true                         |  false   | Defines if module must be registered in the API Gateway (it will create for itself service and list of routes from module descriptor)                                                                      |
 | ROUTER_PATH_PREFIX                       |                              |  false   | Defines routes prefix to be added to the generated endpoints by OpenAPI generator (`/foo/entites` -> `{{prefix}}/foo/entities`). Required if load balancing group has format like `{{host}}/{{moduleId}}`  |
+
+### Deprecated environment variables
+
+The Kong-specific names below are still functional: each one is used when its replacement is not set.
+A `WARN` message is logged at startup for every deprecated name that is in use.
+Support for them is planned to be removed in the `Vetch` flower release.
+
+| Deprecated name                | Replacement                     |
+|:-------------------------------|:--------------------------------|
+| `KONG_INTEGRATION_ENABLED`     | `APIGW_ENABLED`                 |
+| `KONG_ADMIN_URL`               | `APIGW_URL`                     |
+| `REGISTER_MODULE_IN_KONG`      | `APIGW_REGISTER_MODULE`         |
+| `KONG_CONNECT_TIMEOUT`         | `APIGW_CONNECT_TIMEOUT`         |
+| `KONG_READ_TIMEOUT`            | `APIGW_READ_TIMEOUT`            |
+| `KONG_WRITE_TIMEOUT`           | `APIGW_WRITE_TIMEOUT`           |
+| `KONG_RETRIES`                 | `APIGW_RETRIES`                 |
+| `KONG_TLS_ENABLED`             | `APIGW_TLS_ENABLED`             |
+| `KONG_TLS_TRUSTSTORE_PATH`     | `APIGW_TLS_TRUSTSTORE_PATH`     |
+| `KONG_TLS_TRUSTSTORE_PASSWORD` | `APIGW_TLS_TRUSTSTORE_PASSWORD` |
+| `KONG_TLS_TRUSTSTORE_TYPE`     | `APIGW_TLS_TRUSTSTORE_TYPE`     |
+
+Configuration properties follow the same rule: every `application.kong.*` property maps 1:1 to the
+matching `application.apigw.*` property.
 
 ### SSL Configuration environment variables
 
@@ -221,28 +245,28 @@ The feature is controlled by two env variables `SECURITY_ENABLED` and `KC_INTEGR
 | KC_JWKS_REFRESH_INTERVAL          | 60                         |    false    | Jwks refresh interval for realm JWT parser (in minutes).                                                                                                |
 | KC_FORCED_JWKS_REFRESH_INTERVAL   | 60                         |    false    | Forced jwks refresh interval for realm JWT parser (used in signing key rotation, in minutes).                                                           |
 
-## Kong Gateway Integration
+## API Gateway Integration
 
-Kong gateway integration implemented using idempotent approach
+API Gateway integration implemented using idempotent approach
 with [Kong Admin API](https://docs.konghq.com/gateway/latest/admin-api/).
 
-### Kong Self-Registration
+### Gateway Self-Registration
 
 On startup, the module registers itself in the Kong Gateway as a service with a list of routes defined in its module
 descriptor (`descriptors/ModuleDescriptor.json`):
 
 - A Kong Service is created (or updated if it already exists) with the name equal to the module id (e.g. `mgr-applications-4.0.0`)
-- The service URL is taken from the `MODULE_URL` environment variable (the module cannot define the URL for Kong
+- The service URL is taken from the `MODULE_URL` environment variable (the module cannot define the URL for gateway
   registration by itself, because it can be under a Load Balancer, so this value must be provided manually)
 - Routes are created for all routing entries from the module descriptor
 - Registration is idempotent: on restart, the existing service and routes are updated in place
-- Self-registration is controlled by `KONG_INTEGRATION_ENABLED` and `REGISTER_MODULE_IN_KONG` environment variables
+- Self-registration is controlled by `APIGW_ENABLED` and `APIGW_REGISTER_MODULE` environment variables
 
 To view the registered service and its routes in Kong, use:
 
 ```shell
-curl -X GET "$KONG_ADMIN_URL/services"
-curl -X GET "$KONG_ADMIN_URL/services/mgr-applications-4.0.0/routes"
+curl -X GET "$APIGW_URL/services"
+curl -X GET "$APIGW_URL/services/mgr-applications-4.0.0/routes"
 ```
 
 ## Kafka Integration
@@ -272,7 +296,7 @@ curl -XGET "$TE_URL/entitlements?query=applicationId=$applicationId"
 In this mode, we only need a subset of the component's functionality.
 While CRUD operations for application descriptors works as-is,
 the integrations with Kafka, Keycloak, and mgr-tenant-entitlements are disabled.
-Kong self-registration is **not** disabled by FAR mode — set `KONG_INTEGRATION_ENABLED=false` explicitly if it must be off.
+Gateway self-registration is **not** disabled by FAR mode — set `APIGW_ENABLED=false` explicitly if it must be off.
 To enable this mode set `FAR_MODE` env variable to `true` and make sure to leave other integration variables unset or
 set to `false`.
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -46,20 +46,20 @@ application:
     enabled: ${FAR_MODE:false}
   security:
     enabled: ${SECURITY_ENABLED:true}
-  kong:
-    enabled: ${KONG_INTEGRATION_ENABLED:true}
-    url: ${KONG_ADMIN_URL:${kong.url:}}
-    module-self-url: ${MODULE_URL:http://mgr-applications:8081}
-    register-module: ${REGISTER_MODULE_IN_KONG:true}
-    connect-timeout: ${KONG_CONNECT_TIMEOUT:}
-    read-timeout: ${KONG_READ_TIMEOUT:}
-    write-timeout: ${KONG_WRITE_TIMEOUT:}
-    retries: ${KONG_RETRIES:}
+  apigw:
+    enabled: ${APIGW_ENABLED:${KONG_INTEGRATION_ENABLED:${application.kong.enabled:true}}}
+    url: ${APIGW_URL:${KONG_ADMIN_URL:${application.kong.url:${kong.url:}}}}
+    module-self-url: ${MODULE_URL:${application.kong.module-self-url:http://mgr-applications:8081}}
+    register-module: ${APIGW_REGISTER_MODULE:${REGISTER_MODULE_IN_KONG:${application.kong.register-module:true}}}
+    connect-timeout: ${APIGW_CONNECT_TIMEOUT:${KONG_CONNECT_TIMEOUT:${application.kong.connect-timeout:}}}
+    read-timeout: ${APIGW_READ_TIMEOUT:${KONG_READ_TIMEOUT:${application.kong.read-timeout:}}}
+    write-timeout: ${APIGW_WRITE_TIMEOUT:${KONG_WRITE_TIMEOUT:${application.kong.write-timeout:}}}
+    retries: ${APIGW_RETRIES:${KONG_RETRIES:${application.kong.retries:}}}
     tls:
-      enabled: ${KONG_TLS_ENABLED:false}
-      trust-store-path: ${KONG_TLS_TRUSTSTORE_PATH:}
-      trust-store-password: ${KONG_TLS_TRUSTSTORE_PASSWORD:}
-      trust-store-type: ${KONG_TLS_TRUSTSTORE_TYPE:}
+      enabled: ${APIGW_TLS_ENABLED:${KONG_TLS_ENABLED:${application.kong.tls.enabled:false}}}
+      trust-store-path: ${APIGW_TLS_TRUSTSTORE_PATH:${KONG_TLS_TRUSTSTORE_PATH:${application.kong.tls.trust-store-path:}}}
+      trust-store-password: ${APIGW_TLS_TRUSTSTORE_PASSWORD:${KONG_TLS_TRUSTSTORE_PASSWORD:${application.kong.tls.trust-store-password:}}}
+      trust-store-type: ${APIGW_TLS_TRUSTSTORE_TYPE:${KONG_TLS_TRUSTSTORE_TYPE:${application.kong.tls.trust-store-type:}}}
   environment: ${ENV:folio}
   kafka:
     producer:

--- a/src/test/java/org/folio/am/it/ApplicationDiscoveryNoIntegrationsIT.java
+++ b/src/test/java/org/folio/am/it/ApplicationDiscoveryNoIntegrationsIT.java
@@ -43,7 +43,7 @@ import org.springframework.test.context.jdbc.SqlMergeMode;
 @IntegrationTest
 @SqlMergeMode(MERGE)
 @Sql(scripts = "classpath:/sql/truncate-tables.sql", executionPhase = AFTER_TEST_METHOD)
-@TestPropertySource(properties = "application.kong.enabled=false")
+@TestPropertySource(properties = "application.apigw.enabled=false")
 class ApplicationDiscoveryNoIntegrationsIT extends BaseIntegrationTest {
 
   @BeforeAll

--- a/src/test/java/org/folio/am/it/ApplicationFarModeIT.java
+++ b/src/test/java/org/folio/am/it/ApplicationFarModeIT.java
@@ -31,7 +31,7 @@ import org.springframework.test.context.jdbc.Sql;
 @IntegrationTest
 @Sql(scripts = "classpath:/sql/application-descriptor.sql", executionPhase = BEFORE_TEST_METHOD)
 @Sql(scripts = "classpath:/sql/truncate-tables.sql", executionPhase = AFTER_TEST_METHOD)
-@TestPropertySource(properties = {"application.far-mode.enabled=true", "application.kong.enabled=false"})
+@TestPropertySource(properties = {"application.far-mode.enabled=true", "application.apigw.enabled=false"})
 class ApplicationFarModeIT extends BaseIntegrationTest {
 
   @Test

--- a/src/test/java/org/folio/am/it/ApplicationValidateInFarModeIT.java
+++ b/src/test/java/org/folio/am/it/ApplicationValidateInFarModeIT.java
@@ -42,7 +42,7 @@ import org.springframework.test.context.jdbc.Sql;
 @Sql(scripts = "classpath:/sql/truncate-tables.sql", executionPhase = AFTER_TEST_METHOD)
 @TestPropertySource(properties = {
   "application.far-mode.enabled=true",
-  "application.kong.enabled=false"
+  "application.apigw.enabled=false"
 })
 class ApplicationValidateInFarModeIT  extends BaseBackendIntegrationTest {
 

--- a/src/test/java/org/folio/am/it/KongRegistrationIT.java
+++ b/src/test/java/org/folio/am/it/KongRegistrationIT.java
@@ -13,8 +13,8 @@ import org.springframework.test.context.TestPropertySource;
 @TestPropertySource(properties = {
   "application.security.enabled=true",
   "application.keycloak.enabled=false",
-  "application.kong.module-self-url=https://test-mgr-applications:443",
-  "application.kong.register-module=true",
+  "application.apigw.module-self-url=https://test-mgr-applications:443",
+  "application.apigw.register-module=true",
 })
 class KongRegistrationIT extends BaseIntegrationTest {
 

--- a/src/test/java/org/folio/am/it/LegacyGatewayPropertiesIT.java
+++ b/src/test/java/org/folio/am/it/LegacyGatewayPropertiesIT.java
@@ -1,0 +1,65 @@
+package org.folio.am.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.folio.am.support.base.BaseIntegrationTest;
+import org.folio.test.types.IntegrationTest;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.TestPropertySource;
+
+@IntegrationTest
+class LegacyGatewayPropertiesIT {
+
+  private static final String ADMIN_CLIENT_BEAN = "folioKongAdminClient";
+  private static final String DEPRECATION_WARNING =
+    "Configuration property 'application.kong.enabled' is deprecated and will be removed in the Vetch release. "
+      + "Use 'application.apigw.enabled' instead.";
+
+  @Nested
+  @ExtendWith(OutputCaptureExtension.class)
+  @TestPropertySource(properties = "application.kong.enabled=true")
+  class LegacyPropertyEnabled extends BaseIntegrationTest {
+
+    @Autowired private ApplicationContext applicationContext;
+
+    @Test
+    void gatewayIntegration_positive_legacyPropertyEnablesBeans() {
+      assertThat(applicationContext.containsBean(ADMIN_CLIENT_BEAN)).isTrue();
+    }
+
+    @Test
+    void gatewayIntegration_positive_legacyPropertyIsReportedAsDeprecated(CapturedOutput output) {
+      assertThat(output.getAll()).contains(DEPRECATION_WARNING);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(properties = "KONG_INTEGRATION_ENABLED=false")
+  class LegacyVariableDisabled extends BaseIntegrationTest {
+
+    @Autowired private ApplicationContext applicationContext;
+
+    @Test
+    void gatewayIntegration_positive_legacyVariableDisablesBeans() {
+      assertThat(applicationContext.containsBean(ADMIN_CLIENT_BEAN)).isFalse();
+    }
+  }
+
+  @Nested
+  @TestPropertySource(properties = {"KONG_INTEGRATION_ENABLED=false", "APIGW_ENABLED=true"})
+  class NewVariableOverridesLegacyVariable extends BaseIntegrationTest {
+
+    @Autowired private ApplicationContext applicationContext;
+
+    @Test
+    void gatewayIntegration_positive_newVariableTakesPrecedence() {
+      assertThat(applicationContext.containsBean(ADMIN_CLIENT_BEAN)).isTrue();
+    }
+  }
+}

--- a/src/test/java/org/folio/am/it/ModuleBootstrapIT.java
+++ b/src/test/java/org/folio/am/it/ModuleBootstrapIT.java
@@ -41,7 +41,7 @@ import org.springframework.test.context.jdbc.Sql;
 @EnableKeycloakSecurity
 @EnableKeycloakTlsMode
 @EnableKeycloakDataImport
-@TestPropertySource(properties = "application.kong.enabled=false")
+@TestPropertySource(properties = "application.apigw.enabled=false")
 @Sql(scripts = "classpath:/sql/truncate-tables.sql", executionPhase = AFTER_TEST_METHOD)
 class ModuleBootstrapIT extends BaseIntegrationTest {
 

--- a/src/test/resources/log4j2-test.properties
+++ b/src/test/resources/log4j2-test.properties
@@ -1,0 +1,17 @@
+status = error
+name = PropertiesConfig
+packages = org.folio.spring.logging
+
+appenders = console
+
+appender.console.type = Console
+appender.console.name = STDOUT
+# resolves System.out on every write so tests can capture log output
+appender.console.follow = true
+
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{HH:mm:ss} %-5p %-20.20C{1} %m%n
+
+rootLogger.level = info
+rootLogger.appenderRefs = stdout
+rootLogger.appenderRef.stdout.ref = STDOUT


### PR DESCRIPTION
## Purpose

Prerequisite refactor for supporting multiple API gateways: this service adopts the generalized `APIGW_*` environment variables and `application.apigw.*` properties introduced by the shared library, while keeping every legacy `KONG_*` / `application.kong.*` name working (with a startup deprecation WARN) until the Vetch release.

US: [EUREKA-887](https://folio-org.atlassian.net/browse/EUREKA-887)

## Approach

After MGRAPPS-108 removed Kong route management from this service, its only gateway integration is startup self-registration via the shared library. The `application.kong.*` block in `application.yml` becomes an `application.apigw.*` block whose values are placeholder chains resolving new env var, then legacy env var, then legacy property, then the previous default — so precedence is explicit and any operator configuration that worked before still works. No production Java changes.

- Replaced the `application.kong.*` configuration block with `application.apigw.*` placeholder chains of the form `${APIGW_X:${KONG_X:${application.kong.x:default}}}`; all previous defaults are preserved, including the `${kong.url:}` fallback.

**Merge coordination:** requires the `applications-poc-tools` EUREKA-887 PR (folio-org/applications-poc-tools#355) to be merged first (library prefix flip); the maven check on this PR stays red until that PR merges and publishes its snapshot. Land all EUREKA-887 PRs in the same window.

## Pre-Review Checklist

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Dependent module build verification** — Ran manually when library changes impact downstream modules.
  > Actions → Verify Dependent Modules → Run workflow → select branch → Run.
- [ ] **Breaking Changes (if any)** — Handled if changes affect integration with other services.
- [x] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
